### PR TITLE
Fix CI backend build in E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,9 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Build Backend
+        run: ./mvnw clean package -DskipTests
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Adds a Maven build step to `.github/workflows/test.yml` for the frontend-e2e job so that the backend starts correctly before running E2E tests.

Other issues reported (like vulnerabilities on 22.12.0 or syntax errors in login.spec.ts) were found to be invalid/false positives and are not changed.

---
*PR created automatically by Jules for task [5495633061611494911](https://jules.google.com/task/5495633061611494911) started by @phalbohr*