### PR TITLE
Fix JWT Revocation Bloom Filter Performance and Logout Wiring

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
       - 'POSTGRES_PASSWORD=secret'
       - 'POSTGRES_USER=myuser'
     ports:
-      - '5433:5432' # Хост-порт изменен на 5433 во избежание конфликта
+      - '5433:5432' # Host port changed to 5433 to avoid conflict
   redis:
-    image: 'redis/redis-stack:latest'
+    image: 'redis:7-alpine'
     ports:
       - '6379:6379'

--- a/frontend/e2e/scenarios/login.spec.ts
+++ b/frontend/e2e/scenarios/login.spec.ts
@@ -15,8 +15,8 @@ test.describe('Login Flow', () => {
   });
 
   test('should redirect to Google OAuth2 endpoint when clicking sign in', async ({ page }) => {
-    // Перехватываем запрос к серверам Google, чтобы избежать ошибки 
-    // "This browser or app may not be secure" (защита от ботов)
+    // Intercept requests to Google servers to avoid the error
+    // "This browser or app may not be secure" (bot protection)
     await page.route('**/*accounts.google.com/**', route => {
       route.fulfill({
         status: 200,
@@ -30,17 +30,17 @@ test.describe('Login Flow', () => {
     const signInButton = page.getByRole('button', { name: /Sign in with Google/i });
     await expect(signInButton).toBeVisible();
 
-    // Chromium может "зависать" на навигации, если мы ее мокаем.
-    // Поэтому просто дождемся, пока браузер попытается сделать запрос на нужный URL.
+    // Chromium might "hang" on navigation if we mock it.
+    // So we just wait until the browser attempts to make a request to the needed URL.
     const redirectPromise = page.waitForRequest(req => 
       req.url().includes('oauth2/authorization/google') || 
       req.url().includes('accounts.google.com')
     );
 
-    // Кликаем без ожидания полного завершения навигации
+    // Click without waiting for full navigation to complete
     await signInButton.click({ noWaitAfter: true });
 
-    // Дожидаемся запроса. Если он ушел — значит кнопка отработала корректно.
+    // Wait for the request. If it was sent, the button works correctly.
     await redirectPromise;
   });
 });

--- a/frontend/src/views/HomeHub.vue
+++ b/frontend/src/views/HomeHub.vue
@@ -20,6 +20,7 @@ const authStore = useAuthStore()
     <div v-else class="flex flex-col items-center gap-4">
       <p class="text-gray-700 text-xl">Welcome back! 👋</p>
       <p class="text-gray-500">Your foosball dashboard is coming soon.</p>
+      <button @click="authStore.logout()" class="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition">Sign Out</button>
     </div>
   </main>
 </template>

--- a/src/main/java/com/tictactore/controller/AuthController.java
+++ b/src/main/java/com/tictactore/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.tictactore.controller;
 
 import com.tictactore.security.CustomOAuth2SuccessHandler;
 import com.tictactore.service.TokenRevocationService;
+import com.tictactore.service.JwtService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,10 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final TokenRevocationService tokenRevocationService;
+    private final JwtService jwtService;
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-        String token = extractToken(request);
+        String token = jwtService.extractToken(request);
         if (token != null) {
             tokenRevocationService.revoke(token);
         }
@@ -39,21 +41,5 @@ public class AuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
 
         return ResponseEntity.ok().build();
-    }
-
-    private String extractToken(HttpServletRequest request) {
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            return authHeader.substring(7);
-        }
-
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if (CustomOAuth2SuccessHandler.AUTH_COOKIE_NAME.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/com/tictactore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tictactore/security/JwtAuthenticationFilter.java
@@ -32,48 +32,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        String token = extractToken(request);
+        String token = jwtService.extractToken(request);
 
         if (token != null && jwtService.isTokenValid(token)) {
-            if (tokenRevocationService.isRevoked(token)) {
-                // Не устанавливаем SecurityContext — запрос уходит дальше как анонимный
-                filterChain.doFilter(request, response);
-                return;
-            }
-
-            // Performance: Database Exhaustion in JWT Filter - Rely on JWT claims instead of DB lookup.
-            String userId = jwtService.extractUserId(token);
+            if (!tokenRevocationService.isRevoked(token)) {
+                // Performance: Database Exhaustion in JWT Filter - Rely on JWT claims instead of DB lookup.
+                String userId = jwtService.extractUserId(token);
             // We reconstruct a minimal User object from JWT claims to avoid DB hit.
             // If the application logic needs more user details, it can load them when needed.
             User user = User.builder()
                     .id(UUID.fromString(userId))
                     .build();
 
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    user, 
-                    null, 
-                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
-            );
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        user,
+                        null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                );
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String extractToken(HttpServletRequest request) {
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            return authHeader.substring(7);
-        }
-
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if (CustomOAuth2SuccessHandler.AUTH_COOKIE_NAME.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/com/tictactore/service/JwtService.java
+++ b/src/main/java/com/tictactore/service/JwtService.java
@@ -5,6 +5,9 @@ import com.tictactore.model.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import com.tictactore.security.CustomOAuth2SuccessHandler;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -45,6 +48,26 @@ public class JwtService {
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    public Date extractExpirationDate(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    public String extractToken(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (CustomOAuth2SuccessHandler.AUTH_COOKIE_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 
     private Claims parseClaims(String token) {

--- a/src/main/java/com/tictactore/service/impl/RedisTokenRevocationService.java
+++ b/src/main/java/com/tictactore/service/impl/RedisTokenRevocationService.java
@@ -2,6 +2,7 @@ package com.tictactore.service.impl;
 
 import com.tictactore.config.ApplicationProperties;
 import com.tictactore.service.TokenRevocationService;
+import com.tictactore.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBloomFilter;
@@ -10,6 +11,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Date;
 
 @Slf4j
 @Service
@@ -25,20 +27,7 @@ public class RedisTokenRevocationService implements TokenRevocationService {
 
     private final RedissonClient redissonClient;
     private final ApplicationProperties properties;
-
-    /**
-     * Gets or initializes a bloom filter for a specific epoch day.
-     */
-    private RBloomFilter<String> getBloomFilterForDay(long epochDay) {
-        String filterName = BLOOM_FILTER_PREFIX + epochDay;
-        RBloomFilter<String> bloomFilter = redissonClient.getBloomFilter(filterName);
-        boolean initialized = bloomFilter.tryInit(EXPECTED_ELEMENTS, FALSE_POSITIVE_RATE);
-        if (initialized) {
-            bloomFilter.expire(Duration.ofHours(48));
-            log.info("Created new Bloom Filter: {}", filterName);
-        }
-        return bloomFilter;
-    }
+    private final JwtService jwtService;
 
     @Override
     public void revoke(String token) {
@@ -46,26 +35,42 @@ public class RedisTokenRevocationService implements TokenRevocationService {
             return;
         }
 
-        long expirationMs = properties.getJwt().getExpiration();
-        Duration tokenTtl = Duration.ofMillis(expirationMs);
+        Date expirationDate;
+        try {
+            expirationDate = jwtService.extractExpirationDate(token);
+        } catch (Exception e) {
+            log.warn("Failed to extract expiration from token during revocation, using default");
+            expirationDate = new Date(System.currentTimeMillis() + properties.getJwt().getExpiration());
+        }
 
+        long remainingTtlMs = expirationDate.getTime() - System.currentTimeMillis();
+        if (remainingTtlMs <= 0) {
+            return;
+        }
+
+        Duration tokenTtl = Duration.ofMillis(remainingTtlMs);
         long currentDay = getCurrentEpochDay();
+        long expirationDay = expirationDate.getTime() / 86400000L;
 
         try {
-            // 1. Add to TODAY'S bloom filter
-            RBloomFilter<String> todayFilter = getBloomFilterForDay(currentDay);
-            todayFilter.add(token);
-            
-            long count = todayFilter.count();
-            if (count > EXPECTED_ELEMENTS * 0.8) {
-                log.warn("Bloom Filter {} is at {}% capacity", todayFilter.getName(), count * 100 / EXPECTED_ELEMENTS);
+            for (long day = currentDay; day <= expirationDay; day++) {
+                String filterName = BLOOM_FILTER_PREFIX + day;
+                RBloomFilter<String> filter = redissonClient.getBloomFilter(filterName);
+                boolean initialized = filter.tryInit(EXPECTED_ELEMENTS, FALSE_POSITIVE_RATE);
+                if (initialized) {
+                    log.info("Created new Bloom Filter: {}", filterName);
+                }
+                filter.add(token);
+
+                if (day == currentDay) {
+                    long count = filter.count();
+                    if (count > EXPECTED_ELEMENTS * 0.8) {
+                        log.warn("Bloom Filter {} is at {}% capacity", filterName, count * 100 / EXPECTED_ELEMENTS);
+                    }
+                }
             }
 
-            // 2. Add to TOMORROW'S bloom filter (in case the token's 24h lifespan crosses midnight)
-            RBloomFilter<String> tomorrowFilter = getBloomFilterForDay(currentDay + 1);
-            tomorrowFilter.add(token);
-
-            // 3. Add exact record to Redis as a bucket key
+            // Add exact record to Redis as a bucket key with precise TTL
             RBucket<String> bucket = redissonClient.getBucket(KEY_PREFIX + token);
             bucket.set("revoked", tokenTtl);
 
@@ -85,11 +90,14 @@ public class RedisTokenRevocationService implements TokenRevocationService {
         long currentDay = getCurrentEpochDay();
 
         try {
-            RBloomFilter<String> todayFilter = getBloomFilterForDay(currentDay);
-            RBloomFilter<String> yesterdayFilter = getBloomFilterForDay(currentDay - 1);
+            RBloomFilter<String> todayFilter = redissonClient.getBloomFilter(BLOOM_FILTER_PREFIX + currentDay);
+            RBloomFilter<String> yesterdayFilter = redissonClient.getBloomFilter(BLOOM_FILTER_PREFIX + (currentDay - 1));
 
             // Fast path: Rolling Bloom filter for current day and yesterday
-            if (!todayFilter.contains(token) && !yesterdayFilter.contains(token)) {
+            boolean inToday = todayFilter.isExists() && todayFilter.contains(token);
+            boolean inYesterday = yesterdayFilter.isExists() && yesterdayFilter.contains(token);
+
+            if (!inToday && !inYesterday) {
                 return false; // Definitely not in the denylist
             }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,10 +2,6 @@ spring:
   docker:
     compose:
       enabled: true
-  data:
-    redis:
-      host: localhost
-      port: 6379
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
     driverClassName: org.h2.Driver

--- a/src/test/java/com/tictactore/controller/AuthControllerTest.java
+++ b/src/test/java/com/tictactore/controller/AuthControllerTest.java
@@ -51,6 +51,7 @@ class AuthControllerTest {
     @WithMockUser
     void logout_withCsrf_revokesTokenAndClearsCookie() throws Exception {
         String token = "test-token";
+        org.mockito.Mockito.when(jwtService.extractToken(org.mockito.ArgumentMatchers.any())).thenReturn(token);
         
         mockMvc.perform(post("/api/auth/logout")
                 .cookie(new Cookie(CustomOAuth2SuccessHandler.AUTH_COOKIE_NAME, token))

--- a/src/test/java/com/tictactore/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/tictactore/security/JwtAuthenticationFilterTest.java
@@ -42,7 +42,7 @@ class JwtAuthenticationFilterTest {
     @Test
     void doFilterInternal_validToken_notRevoked() throws Exception {
         String token = "valid.token";
-        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(jwtService.extractToken(request)).thenReturn(token);
         when(jwtService.isTokenValid(token)).thenReturn(true);
         when(tokenRevocationService.isRevoked(token)).thenReturn(false);
         when(jwtService.extractUserId(token)).thenReturn("123e4567-e89b-12d3-a456-426614174000");
@@ -57,7 +57,7 @@ class JwtAuthenticationFilterTest {
     @Test
     void doFilterInternal_validToken_isRevoked() throws Exception {
         String token = "revoked.token";
-        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(jwtService.extractToken(request)).thenReturn(token);
         when(jwtService.isTokenValid(token)).thenReturn(true);
         when(tokenRevocationService.isRevoked(token)).thenReturn(true);
 
@@ -71,9 +71,7 @@ class JwtAuthenticationFilterTest {
     @Test
     void doFilterInternal_cookieToken_notRevoked() throws Exception {
         String token = "valid.token.from.cookie";
-        Cookie cookie = new Cookie(CustomOAuth2SuccessHandler.AUTH_COOKIE_NAME, token);
-        when(request.getHeader("Authorization")).thenReturn(null);
-        when(request.getCookies()).thenReturn(new Cookie[]{cookie});
+        when(jwtService.extractToken(request)).thenReturn(token);
         when(jwtService.isTokenValid(token)).thenReturn(true);
         when(tokenRevocationService.isRevoked(token)).thenReturn(false);
         when(jwtService.extractUserId(token)).thenReturn("123e4567-e89b-12d3-a456-426614174000");

--- a/src/test/java/com/tictactore/service/impl/RedisTokenRevocationServiceTest.java
+++ b/src/test/java/com/tictactore/service/impl/RedisTokenRevocationServiceTest.java
@@ -10,6 +10,9 @@ import org.redisson.api.RBloomFilter;
 import org.redisson.api.RBucket;
 import org.redisson.api.RedissonClient;
 
+import com.tictactore.service.JwtService;
+import java.util.Date;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -24,6 +27,8 @@ class RedisTokenRevocationServiceTest {
     private ApplicationProperties properties;
     @Mock
     private ApplicationProperties.Jwt jwtProperties;
+    @Mock
+    private JwtService jwtService;
     
     @Mock
     private RBloomFilter<String> todayBloomFilter;
@@ -41,8 +46,8 @@ class RedisTokenRevocationServiceTest {
 
     // We extend the service to control the concept of "current time/day" for predictability in tests.
     private class TestableRedisTokenRevocationService extends RedisTokenRevocationService {
-        public TestableRedisTokenRevocationService(RedissonClient redissonClient, ApplicationProperties properties) {
-            super(redissonClient, properties);
+        public TestableRedisTokenRevocationService(RedissonClient redissonClient, ApplicationProperties properties, JwtService jwtService) {
+            super(redissonClient, properties, jwtService);
         }
 
         @Override
@@ -53,32 +58,26 @@ class RedisTokenRevocationServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new TestableRedisTokenRevocationService(redissonClient, properties);
+        service = new TestableRedisTokenRevocationService(redissonClient, properties, jwtService);
     }
 
     @Test
     void testRevoke() {
         String token = "test.jwt.token";
         
-        when(properties.getJwt()).thenReturn(jwtProperties);
-        when(jwtProperties.getExpiration()).thenReturn(86400000L); // 24h
+        Date expirationDate = new Date(System.currentTimeMillis() + 86400000L); // 24h
+        when(jwtService.extractExpirationDate(token)).thenReturn(expirationDate);
         
         String todayFilterName = "jwt_denylist_bloom:" + MOCK_EPOCH_DAY;
-        String tomorrowFilterName = "jwt_denylist_bloom:" + (MOCK_EPOCH_DAY + 1);
+        long expirationDay = expirationDate.getTime() / 86400000L;
 
-        when(redissonClient.<String>getBloomFilter(todayFilterName)).thenReturn(todayBloomFilter);
-        when(redissonClient.<String>getBloomFilter(tomorrowFilterName)).thenReturn(tomorrowBloomFilter);
-        
+        when(redissonClient.<String>getBloomFilter(anyString())).thenReturn(todayBloomFilter);
         when(redissonClient.<String>getBucket("jwt:revoked:" + token)).thenReturn(bucket);
 
         service.revoke(token);
 
-        verify(todayBloomFilter).tryInit(100000L, 0.01);
-        verify(todayBloomFilter).add(token);
-        verify(todayBloomFilter).count();
-
-        verify(tomorrowBloomFilter).tryInit(100000L, 0.01);
-        verify(tomorrowBloomFilter).add(token);
+        verify(todayBloomFilter, atLeastOnce()).tryInit(100000L, 0.01);
+        verify(todayBloomFilter, atLeastOnce()).add(token);
 
         verify(bucket).set(eq("revoked"), any(java.time.Duration.class));
     }
@@ -91,14 +90,16 @@ class RedisTokenRevocationServiceTest {
         
         when(redissonClient.<String>getBloomFilter(todayFilterName)).thenReturn(todayBloomFilter);
         when(redissonClient.<String>getBloomFilter(yesterdayFilterName)).thenReturn(yesterdayBloomFilter);
+        when(todayBloomFilter.isExists()).thenReturn(true);
         when(todayBloomFilter.contains(token)).thenReturn(false);
+        when(yesterdayBloomFilter.isExists()).thenReturn(true);
         when(yesterdayBloomFilter.contains(token)).thenReturn(false);
 
         boolean result = service.isRevoked(token);
 
         assertFalse(result);
-        verify(todayBloomFilter).tryInit(100000L, 0.01);
-        verify(yesterdayBloomFilter).tryInit(100000L, 0.01);
+        verify(todayBloomFilter, never()).tryInit(anyLong(), anyDouble());
+        verify(yesterdayBloomFilter, never()).tryInit(anyLong(), anyDouble());
         verify(redissonClient, never()).getBucket(anyString());
     }
 
@@ -111,7 +112,9 @@ class RedisTokenRevocationServiceTest {
         when(redissonClient.<String>getBloomFilter(todayFilterName)).thenReturn(todayBloomFilter);
         when(redissonClient.<String>getBloomFilter(yesterdayFilterName)).thenReturn(yesterdayBloomFilter);
         // Let's say it's not in today's, but it's in yesterday's filter
+        when(todayBloomFilter.isExists()).thenReturn(true);
         when(todayBloomFilter.contains(token)).thenReturn(false);
+        when(yesterdayBloomFilter.isExists()).thenReturn(true);
         when(yesterdayBloomFilter.contains(token)).thenReturn(true);
         when(redissonClient.<String>getBucket("jwt:revoked:" + token)).thenReturn(bucket);
         when(bucket.isExists()).thenReturn(true);
@@ -130,6 +133,7 @@ class RedisTokenRevocationServiceTest {
         when(redissonClient.<String>getBloomFilter(todayFilterName)).thenReturn(todayBloomFilter);
         when(redissonClient.<String>getBloomFilter(yesterdayFilterName)).thenReturn(yesterdayBloomFilter);
         // Let's say it's in today's filter
+        when(todayBloomFilter.isExists()).thenReturn(true);
         when(todayBloomFilter.contains(token)).thenReturn(true);
         when(redissonClient.<String>getBucket("jwt:revoked:" + token)).thenReturn(bucket);
         when(bucket.isExists()).thenReturn(false);


### PR DESCRIPTION
This commit addresses a series of blocking and warning issues raised during PR review. The changes eliminate performance overhead from redundant Bloom Filter initializations in Redis, implement precise JWT token expiration logic, ensure persistent Bloom Filter records, fix Spring Security public endpoint blocking for revoked tokens, centralize JWT extraction, wire up the frontend logout button, and clean up configuration and comments.

---
*PR created automatically by Jules for task [16510756336907110801](https://jules.google.com/task/16510756336907110801) started by @phalbohr*