### PR TITLE
fix: Add TTL to dynamically created Bloom Filters

### DIFF
--- a/src/main/java/com/tictactore/service/impl/RedisTokenRevocationService.java
+++ b/src/main/java/com/tictactore/service/impl/RedisTokenRevocationService.java
@@ -58,6 +58,7 @@ public class RedisTokenRevocationService implements TokenRevocationService {
                 RBloomFilter<String> filter = redissonClient.getBloomFilter(filterName);
                 boolean initialized = filter.tryInit(EXPECTED_ELEMENTS, FALSE_POSITIVE_RATE);
                 if (initialized) {
+                    filter.expire(Duration.ofDays((day - currentDay) + 2));
                     log.info("Created new Bloom Filter: {}", filterName);
                 }
                 filter.add(token);

--- a/src/test/java/com/tictactore/service/impl/RedisTokenRevocationServiceTest.java
+++ b/src/test/java/com/tictactore/service/impl/RedisTokenRevocationServiceTest.java
@@ -73,10 +73,12 @@ class RedisTokenRevocationServiceTest {
 
         when(redissonClient.<String>getBloomFilter(anyString())).thenReturn(todayBloomFilter);
         when(redissonClient.<String>getBucket("jwt:revoked:" + token)).thenReturn(bucket);
+        when(todayBloomFilter.tryInit(100000L, 0.01)).thenReturn(true);
 
         service.revoke(token);
 
         verify(todayBloomFilter, atLeastOnce()).tryInit(100000L, 0.01);
+        verify(todayBloomFilter, atLeastOnce()).expire(any(java.time.Duration.class));
         verify(todayBloomFilter, atLeastOnce()).add(token);
 
         verify(bucket).set(eq("revoked"), any(java.time.Duration.class));


### PR DESCRIPTION
Added a TTL calculation for dynamically generated Bloom filters in `RedisTokenRevocationService.java`. The `tryInit` logic now correctly triggers `filter.expire(...)` when initialized is true. Added test assertions.

---
*PR created automatically by Jules for task [8979065447327706001](https://jules.google.com/task/8979065447327706001) started by @phalbohr*