### PR TITLE
Fix Redis resource exhaustion, Docker Compose persistence, and code formatting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,9 @@ services:
     image: 'redis:7-alpine'
     ports:
       - '6379:6379'
+    volumes:
+      - redis_:/data
+    command: redis-server --appendonly yes
+
+volumes:
+  redis_:

--- a/src/main/java/com/tictactore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tictactore/security/JwtAuthenticationFilter.java
@@ -38,11 +38,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (!tokenRevocationService.isRevoked(token)) {
                 // Performance: Database Exhaustion in JWT Filter - Rely on JWT claims instead of DB lookup.
                 String userId = jwtService.extractUserId(token);
-            // We reconstruct a minimal User object from JWT claims to avoid DB hit.
-            // If the application logic needs more user details, it can load them when needed.
-            User user = User.builder()
-                    .id(UUID.fromString(userId))
-                    .build();
+                // We reconstruct a minimal User object from JWT claims to avoid DB hit.
+                // If the application logic needs more user details, it can load them when needed.
+                User user = User.builder()
+                        .id(UUID.fromString(userId))
+                        .build();
 
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                         user,

--- a/src/main/java/com/tictactore/service/impl/RedisTokenRevocationService.java
+++ b/src/main/java/com/tictactore/service/impl/RedisTokenRevocationService.java
@@ -39,8 +39,8 @@ public class RedisTokenRevocationService implements TokenRevocationService {
         try {
             expirationDate = jwtService.extractExpirationDate(token);
         } catch (Exception e) {
-            log.warn("Failed to extract expiration from token during revocation, using default");
-            expirationDate = new Date(System.currentTimeMillis() + properties.getJwt().getExpiration());
+            log.warn("Unparseable token submitted to revoke endpoint — aborting revocation");
+            return;
         }
 
         long remainingTtlMs = expirationDate.getTime() - System.currentTimeMillis();


### PR DESCRIPTION
This branch contains fixes for the three issues reported:
1. **[BLOCKING] Resource Exhaustion in `RedisTokenRevocationService.java`**: Addressed by making the method cleanly abort when it fails to parse a JWT during revocation, preventing attackers from flooding Redis and Bloom-filters with invalid entries.
2. **[WARN] Redis persistence in `docker-compose.yaml`**: Addressed by mapping a volume (`redis_:/data`) and adding `command: redis-server --appendonly yes` to ensure data isn't lost on restart.
3. **[NIT] Indentation in `JwtAuthenticationFilter.java`**: Addressed by appropriately aligning the `User.builder()` block and related code snippets to match the surrounding 16-space indentation block.

---
*PR created automatically by Jules for task [6327601787969723007](https://jules.google.com/task/6327601787969723007) started by @phalbohr*