### PR TITLE
fix: disable docker compose for backend in playwright tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -118,7 +118,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: 'cd .. && TTT_GOOGLE_CLIENT_ID=dummy TTT_GOOGLE_CLIENT_SECRET=dummy ./mvnw spring-boot:run',
+      command: 'cd .. && SPRING_DOCKER_COMPOSE_ENABLED=false TTT_GOOGLE_CLIENT_ID=dummy TTT_GOOGLE_CLIENT_SECRET=dummy ./mvnw spring-boot:run',
       port: 8080,
       reuseExistingServer: !process.env.CI,
     },


### PR DESCRIPTION
Fix playwright e2e tests failing due to Docker Hub pull rate limit when Spring Boot docker-compose tries to pull postgres/redis images.

---
*PR created automatically by Jules for task [12849169252782342353](https://jules.google.com/task/12849169252782342353) started by @phalbohr*