### PR TITLE
🧪 test: Add testing for getH2HStats non-paged response fallback

### DIFF
--- a/frontend/src/services/__tests__/statisticsService.spec.ts
+++ b/frontend/src/services/__tests__/statisticsService.spec.ts
@@ -45,6 +45,53 @@ describe('statisticsService', () => {
     expect(result).toEqual(mockH2H)
   })
 
+  it('handles fallback for non-paged H2H stats response', async () => {
+    const mockH2HArray = [
+      {
+        opponentId: 'opp-1',
+        opponentName: 'Rival 1',
+        matches: 5,
+        wins: 3,
+        losses: 2,
+        winRate: 60.0
+      },
+      {
+        opponentId: 'opp-2',
+        opponentName: 'Rival 2',
+        matches: 10,
+        wins: 5,
+        losses: 5,
+        winRate: 50.0
+      }
+    ]
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockH2HArray
+    } as Response)
+
+    const result = await getH2HStats({
+      period: 'ALL_TIME',
+      token: 'test-token'
+    })
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/statistics/h2h?period=ALL_TIME'),
+      expect.objectContaining({
+        headers: {
+          'Authorization': 'Bearer test-token'
+        }
+      })
+    )
+    expect(result).toEqual({
+      content: mockH2HArray,
+      totalPages: 1,
+      totalElements: 2,
+      size: 2,
+      number: 0
+    })
+  })
+
   it('fetches personal stats correctly', async () => {
     const mockStats: PlayerStats = {
       playerId: 'user-uuid',


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested branch in `getH2HStats` handling non-paged responses where a plain array of `H2HStats` is returned instead of a `Page` object.
📊 **Coverage:** The scenario now tested mocks a non-paged array response from the backend and asserts that it's transformed properly into a valid `Page` object with accurate sizes and totals.
✨ **Result:** Test coverage for `getH2HStats` function in `statisticsService.ts` is improved, preventing possible regressions when handling fallback payload cases.

---
*PR created automatically by Jules for task [8042644053823448261](https://jules.google.com/task/8042644053823448261) started by @phalbohr*