### PR TITLE
🧪 Testing Improvement: Untested error parsing in apiFetch

### DIFF
--- a/frontend/src/services/__tests__/statisticsService.spec.ts
+++ b/frontend/src/services/__tests__/statisticsService.spec.ts
@@ -126,4 +126,16 @@ describe('statisticsService', () => {
 
     await expect(getLeaderboard({})).rejects.toThrow('Invalid parameters')
   })
+
+  it('handles fetch failure with invalid JSON body', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => {
+        throw new Error('Invalid JSON')
+      }
+    } as unknown as Response)
+
+    await expect(getLeaderboard({})).rejects.toThrow('API error: 400')
+  })
 })


### PR DESCRIPTION
🎯 **What:** 
The issue of "untested error parsing in apiFetch" where a non-OK response contains invalid JSON was unverified.

📊 **Coverage:** 
A new unit test `handles fetch failure with invalid JSON body` was added to `statisticsService.spec.ts` to simulate a failed fetch and JSON rejection (status `400`), confirming it correctly defaults to the fallback message. 

✨ **Result:**
Test coverage has increased; the error fallback is strictly validated and safe against breaking modifications inside the promise rejection block. All unit tests (`vitest`) and integration checks (`playwright`) pass reliably.

---
*PR created automatically by Jules for task [13146502803172931580](https://jules.google.com/task/13146502803172931580) started by @phalbohr*