### PR TITLE
🔒 Secure H2 Database Console exposure

### DIFF
--- a/src/main/java/com/tictactore/config/SecurityConfig.java
+++ b/src/main/java/com/tictactore/config/SecurityConfig.java
@@ -5,6 +5,9 @@ import com.tictactore.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -12,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -20,6 +24,18 @@ public class SecurityConfig {
 
     private final CustomOAuth2SuccessHandler oAuth2SuccessHandler;
     private final JwtAuthenticationFilter jwtAuthFilter;
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    @Profile("dev")
+    public SecurityFilterChain h2ConsoleSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(new AntPathRequestMatcher("/h2-console/**"))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(fo -> fo.sameOrigin()));
+        return http.build();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -31,7 +47,6 @@ public class SecurityConfig {
                                 "/oauth2/**",
                                 "/login/**",
                                 "/actuator/health",
-                                "/h2-console/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**"
                         ).permitAll()

--- a/src/test/java/com/tictactore/security/H2ConsoleSecurityIT.java
+++ b/src/test/java/com/tictactore/security/H2ConsoleSecurityIT.java
@@ -1,0 +1,29 @@
+package com.tictactore.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("H2 Console Security Tests")
+class H2ConsoleSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Unauthenticated request to H2 console - should be unauthorized in test profile")
+    void unauthenticatedRequestToH2Console_shouldBeUnauthorized() throws Exception {
+        mockMvc.perform(get("/h2-console"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
### 🔒 Secure H2 Database Console exposure

#### 🎯 What:
Secured the H2 Database Console endpoint which was previously exposed to unauthenticated users.

#### ⚠️ Risk:
The `/h2-console/**` endpoint was explicitly permitted in the `SecurityFilterChain`. This allowed anyone with access to the server to interact with the H2 database, posing a significant data exposure and integrity risk.

#### 🛡️ Solution:
- Modified `SecurityConfig.java` to remove `/h2-console/**` from the main `permitAll()` list.
- Implemented a separate `SecurityFilterChain` bean specifically for the H2 console, restricted to the `dev` profile using `@Profile("dev")`.
- Set `Ordered.HIGHEST_PRECEDENCE` on the dev-specific filter chain to ensure it takes precedence when the profile is active.
- Added an integration test `H2ConsoleSecurityIT.java` to verify that unauthenticated requests to `/h2-console` return `401 Unauthorized` in the default/test profile.

---
*PR created automatically by Jules for task [9822793427441910278](https://jules.google.com/task/9822793427441910278) started by @phalbohr*