### PR TITLE
🔒 Fix hardcoded JWT secret and secure configuration using environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+TTT_DB_USERNAME=your_db_username
+TTT_DB_PASSWORD=your_db_password
+TTT_GOOGLE_CLIENT_ID=your_google_client_id
+TTT_GOOGLE_CLIENT_SECRET=your_google_client_secret
+TTT_JWT_SECRET=your_jwt_secret_key_needs_to_be_long_enough
+TTT_OAUTH2_REDIRECT_URI=http://localhost:3000/oauth2/redirect
+TTT_BLOOM_FILTER_EXPECTED_ELEMENTS=100000
+TTT_BLOOM_FILTER_FALSE_POSITIVE_RATE=0.01
+
+POSTGRES_USER=your_postgres_user
+POSTGRES_PASSWORD=your_postgres_password

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 
 ### Graphify ###
 graphify-out/
+.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
     image: 'postgres:16-alpine'
     environment:
       - 'POSTGRES_DB=tictactore'
-      - 'POSTGRES_PASSWORD=secret'
-      - 'POSTGRES_USER=myuser'
+      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
+      - 'POSTGRES_USER=${POSTGRES_USER}'
     ports:
       - '5433:5432' # Host port changed to 5433 to avoid conflict
   redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
 application:
   security:
     jwt:
-      secret-key: ${TTT_JWT_SECRET:743677397A24432646294A404E635266556A586E3272357538782F413F442847}
+      secret-key: ${TTT_JWT_SECRET}
       expiration: 86400000 # 1 day
     oauth2:
       redirect-uri: ${TTT_OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/redirect}


### PR DESCRIPTION
🎯 **What:** Removed hardcoded JWT secret fallback and Postgres credentials from codebase, moving them to environment variables. Created a `.env.example` file.
⚠️ **Risk:** Including hardcoded secrets like JWT keys and database passwords in source code leaves them exposed in version control, making them vulnerable to exfiltration by anyone with repository access. This allows attackers to forge tokens, impersonate users, or access the database.
🛡️ **Solution:** Removed hardcoded fallback values for sensitive data in `application.yml` and replaced them with strict environment variable resolution. `docker-compose.yaml` was also updated to use environment variables instead of hardcoded postgres credentials. A `.env.example` was created with dummy values to show developers how to set up the `.env` file locally. Updated `.gitignore` to ensure `.env` is never tracked in git. Non-sensitive configurations were kept with fallbacks to avoid breaking local setups unnecessarily.

---
*PR created automatically by Jules for task [5822639575209756172](https://jules.google.com/task/5822639575209756172) started by @phalbohr*