### PR TITLE
feat: story 1.3 — automatic profile generation & first entry

### DIFF
--- a/_bmad-output/implementation-artifacts/1-3-automatic-profile-generation-and-first-entry.md
+++ b/_bmad-output/implementation-artifacts/1-3-automatic-profile-generation-and-first-entry.md
@@ -1,0 +1,183 @@
+# Story 1.3: Automatic Profile Generation & First Entry
+
+Status: ready-for-dev
+
+## Story
+
+As a new player,
+I want my profile to be created automatically,
+so that I can start recording matches immediately.
+
+## Acceptance Criteria
+
+1. **Given** first-time authentication via Google OAuth2, **When** profile is created, **Then** nickname is generated from the email prefix (everything before the `@` symbol, e.g., `john.doe@gmail.com` → `john.doe`).
+2. **Given** first-time authentication, **When** profile is created, **Then** a default placeholder avatar is assigned (value: `"placeholder"`).
+3. **Given** an authenticated user, **When** they call `GET /api/v1/users/me`, **Then** the endpoint returns the current user's profile including `id`, `email`, `nickname`, `avatar`, and `language`.
+4. **Given** a returning user (re-login), **When** `findOrCreate` is called, **Then** the existing nickname and avatar are preserved (not overwritten).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Enhance User Entity (AC: 1, 2, 4)
+  - [ ] Add `nickname` field (`String`, nullable = false) to `User.java`
+  - [ ] Add `@Version Long version` field to `User.java` (mandatory per write rules — optimistic locking for all mutable entities)
+  - [ ] Ensure `avatar` field remains present (already exists)
+
+- [ ] Task 2: Update UserService — Profile Initialization (AC: 1, 2, 4)
+  - [ ] Update `findOrCreate()` in `UserService` to set `nickname = emailPrefix(email)` and `avatar = "placeholder"` on new user creation only
+  - [ ] Add private `emailPrefix(String email)` helper method — extracts substring before `@`
+  - [ ] Returning user path must NOT overwrite `nickname` or `avatar` (idempotency preserved)
+  - [ ] Write unit tests in `UserServiceTest` for: nickname from simple email, nickname from email with dots/dashes, returning user preserves profile
+
+- [ ] Task 3: Expose Profile API Endpoint (AC: 3)
+  - [ ] Create `UserProfileResponse` record/DTO in `com.tictactore.controller` (fields: `UUID id`, `String email`, `String nickname`, `String avatar`, `String language`)
+  - [ ] Create `UserController` in `com.tictactore.controller` with `GET /api/v1/users/me`
+  - [ ] Extract current user UUID from JWT claims via `SecurityContextHolder.getContext().getAuthentication().getName()` → parse as `UUID`
+  - [ ] Add `findById(UUID id)` method to `UserService` annotated `@Transactional(readOnly = true)`; throw `ResponseStatusException(HttpStatus.NOT_FOUND)` if absent
+  - [ ] Secure endpoint: `ROLE_USER` required (inherits from existing `SecurityConfig` — no changes needed there)
+  - [ ] Write integration test `UserControllerIT` verifying authenticated request returns 200 with correct profile fields
+
+- [ ] Task 4: Frontend Profile Display (AC: 1, 2, 3)
+  - [ ] Create `frontend/src/features/profile/api/profileApi.ts` — `GET /api/users/me` using the centralized API client in `frontend/src/core/api/`
+  - [ ] Create `frontend/src/features/profile/stores/profileStore.ts` (Pinia, named `useProfileStore`) — state: `{ id, email, nickname, avatar, language }`, action: `fetchProfile()`
+  - [ ] Update `HomeHub.vue` to call `profileStore.fetchProfile()` on mount and display nickname
+  - [ ] Avatar: when `avatar === 'placeholder'` render default SVG fallback — do NOT add external image dependencies (Story 1.6 handles real avatars)
+  - [ ] Write Vitest unit test for `profileStore` — mock `profileApi`, verify state populated correctly
+
+- [ ] Task 5: Verify CI passes
+  - [ ] Run `./scripts/ci-local.sh` — all tests green before marking done
+
+## Dev Notes
+
+### Critical Context: What Already Exists
+
+**`User.java`** (`src/main/java/com/tictactore/model/User.java`):
+- Current fields: `id` (UUID), `email`, `name`, `providerId`, `avatar`, `language`
+- **GAP 1**: No `nickname` field — Google's `name` (display name e.g. "John Doe") is NOT the same as email-prefix nickname
+- **GAP 2**: No `@Version` field — mandatory for all mutable `@Entity` per project write rules (1-write.md §2)
+- `avatar` field already declared but never populated (left `null` on creation)
+
+**`UserService.findOrCreate()`** (`src/main/java/com/tictactore/service/UserService.java`):
+- Creates user with `email`, `name`, `providerId` only — `avatar` and `language` left `null`
+- Race-condition guard via `catch (DataIntegrityViolationException)` — **must be preserved**
+- This is the exact integration point for nickname/avatar initialization
+
+**`CustomOAuth2SuccessHandler.java`** — calls `userService.findOrCreate(email, name, providerId)`. No changes needed here.
+
+**Actual package**: `com.tictactore` — NOT `com.itemis.tictactore` (planning docs are wrong)
+**Actual Spring Boot**: 3.4.5 — NOT 4.0 (planning docs are wrong)
+
+### Architecture Patterns & Constraints
+
+- **Strict Layering** (write rule §6): `UserController` must call `UserService`, NOT `UserRepository` directly
+- **Optimistic Locking** (write rule §2): `@Version Long version` — use wrapper `Long`, NOT primitive `long`. No `@Column` annotation on it.
+- **@Transactional** (write rule §3): `findOrCreate` already `@Transactional`. New `findById` must be `@Transactional(readOnly = true)`
+- **Fail-Fast** (write rule §4): If user not found in `/api/v1/users/me`, throw immediately — `ResponseStatusException(HttpStatus.NOT_FOUND)`
+- **Tell, Don't Ask** (write rule §5): Nickname generation logic belongs in service, not controller
+- **API naming** (architecture): endpoint `GET /api/v1/users/me` — kebab-case, plural, versioned
+- **JSON**: all `UserProfileResponse` fields in camelCase
+- **500-line rule** (AD-IP-04): no source file exceeds 500 lines
+- **DTO boundary**: controller returns `UserProfileResponse` record, never the `User` entity
+
+### JWT / Security Integration
+
+- JWT stores user id in claims (established in Story 1.1/1.1a). `JwtAuthenticationFilter` populates `SecurityContext` with UUID as principal name.
+- In `UserController` extract authenticated user id: `SecurityContextHolder.getContext().getAuthentication().getName()` → `UUID.fromString(...)`.
+- Do NOT add another DB lookup in the filter — performance issue was fixed in Story 1.1 review.
+
+### Database / Persistence
+
+- Dev environment: H2 with `ddl-auto: create` — adding fields to `User.java` is sufficient; no Flyway needed for dev.
+- Check `src/main/resources/db/migration/` — if empty or absent, skip SQL migration file.
+- If Flyway IS active: add `V3__add_nickname_to_users.sql`:
+  ```sql
+  ALTER TABLE users ADD COLUMN nickname VARCHAR(255) NOT NULL DEFAULT '';
+  ALTER TABLE users ADD COLUMN version BIGINT;
+  ```
+
+### Nickname Generation
+
+```java
+private String emailPrefix(String email) {
+    int atIndex = email.indexOf('@');
+    if (atIndex < 0) throw new IllegalArgumentException("Invalid email: " + email);
+    return email.substring(0, atIndex);
+}
+```
+
+- Keep dots, dashes, underscores as-is — no sanitization
+- `john.doe@company.com` → `john.doe`
+- `test_user123@gmail.com` → `test_user123`
+
+### Avatar Placeholder
+
+- Store literal string `"placeholder"` in `avatar` column for new users
+- Frontend: `avatar === 'placeholder'` → render inline SVG fallback (generic person silhouette)
+- Story 1.6 (Avatar Selection & Management) will replace placeholder with real avatar URLs — do not anticipate that work here
+
+### Frontend File Locations
+
+```
+frontend/src/
+├── features/
+│   └── profile/
+│       ├── api/
+│       │   └── profileApi.ts          ← NEW
+│       └── stores/
+│           └── profileStore.ts        ← NEW
+├── core/
+│   └── api/                           ← EXISTING — use this client, not raw fetch
+└── views/
+    └── HomeHub.vue                    ← MODIFY: fetchProfile on mount, display nickname
+```
+
+- Pinia store naming convention: `useProfileStore`
+- Vue custom events: use `ch:` prefix (e.g. `ch:profile-loaded`)
+
+### Testing Standards
+
+- **`UserServiceTest`** (unit, Mockito): test nickname = email prefix on create; avatar = "placeholder" on create; returning user: nickname/avatar NOT overwritten; malformed email → `IllegalArgumentException`
+- **`UserControllerIT`** (integration, `@SpringBootTest` + `@AutoConfigureMockMvc`): authenticated `GET /api/v1/users/me` → 200 with correct fields; unauthenticated → 401/403
+- **Never test Lombok-generated code** (test rule §8) — test behavior, not getters/setters
+- **Frontend Vitest**: `profileStore.test.ts` — mock `profileApi.getProfile()`, call `fetchProfile()`, assert state fields set
+
+### Previous Story Intelligence (1.1 & 1.1a)
+
+- Review finding from 1.1: "Missing avatar and language profile data in player record" — Story 1.3 resolves `avatar` (placeholder). `language` remains `null` until Story 1.4.
+- JWT is now HttpOnly cookie (`TTT_TOKEN`) — no URL param, no localStorage
+- `SecurityContext` principal name = user UUID string (set by `JwtAuthenticationFilter`)
+- Race-condition guard in `findOrCreate` via `DataIntegrityViolationException` — preserve unchanged
+- `AuthController` pattern used interface + impl (`AuthApi` + `AuthController`) — for single endpoint `UserController`, one class is sufficient
+
+### Project Structure Notes
+
+- Backend: `src/main/java/com/tictactore/controller/UserController.java` (new), `UserProfileResponse.java` (new record)
+- Backend: `src/main/java/com/tictactore/service/UserService.java` (modify — add `findById` and `emailPrefix`)
+- Backend: `src/main/java/com/tictactore/model/User.java` (modify — add `nickname`, `@Version`)
+- Backend test: `src/test/java/com/tictactore/controller/UserControllerIT.java` (new)
+- Frontend: `frontend/src/features/profile/api/profileApi.ts` (new)
+- Frontend: `frontend/src/features/profile/stores/profileStore.ts` (new)
+- Frontend: `frontend/src/views/HomeHub.vue` (modify)
+
+### References
+
+- [Source: _project-spec/rules/1-write.md#2. Optimistic Locking] — `@Version Long version`
+- [Source: _project-spec/rules/1-write.md#3. @Transactional] — `readOnly=true` for reads
+- [Source: _project-spec/rules/1-write.md#6. Strict Layering] — service owns reads/writes
+- [Source: _project-spec/rules/2-test.md#1. Core Validity Contract] — behavior, not implementation
+- [Source: _bmad-output/planning-artifacts/architecture.md#Naming Conventions] — REST `/api/v1/users/me`, camelCase JSON
+- [Source: _bmad-output/planning-artifacts/architecture.md#Complete Project Directory Structure] — `features/profile/` location
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 1.3] — AC source
+- [Source: _bmad-output/implementation-artifacts/1-1-project-initialization-and-authentication-via-google-oauth2.md#Completion Notes] — package `com.tictactore`, Spring Boot 3.4.5
+- [Source: _bmad-output/implementation-artifacts/1-1-project-initialization-and-authentication-via-google-oauth2.md#Review Findings 2] — missing avatar flagged; JWT HttpOnly cookie pattern
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,0 +1,110 @@
+# generated: 2026-05-02
+# last_updated: 2026-05-10
+# project: tic-tac-tore
+# project_key: NOKEY
+# tracking_system: file-system
+# story_location: _bmad-output/implementation-artifacts
+
+# STATUS DEFINITIONS:
+# ==================
+# Epic Status:
+#   - backlog: Epic not yet started
+#   - in-progress: Epic actively being worked on
+#   - done: All stories in epic completed
+#
+# Epic Status Transitions:
+#   - backlog → in-progress: Automatically when first story is created (via create-story)
+#   - in-progress → done: Manually when all stories reach 'done' status
+#
+# Story Status:
+#   - backlog: Story only exists in epic file
+#   - ready-for-dev: Story file created in stories folder
+#   - in-progress: Developer actively working on implementation
+#   - review: Ready for code review (via Dev's code-review workflow)
+#   - done: Story completed
+#
+# Retrospective Status:
+#   - optional: Can be completed but not required
+#   - done: Retrospective has been completed
+#
+# WORKFLOW NOTES:
+# ===============
+# - Epic transitions to 'in-progress' automatically when first story is created
+# - Stories can be worked in parallel if team capacity allows
+# - SM typically creates next story after previous one is 'done' to incorporate learnings
+# - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
+
+generated: "2026-05-02"
+last_updated: "2026-05-14"
+project: tic-tac-tore
+project_key: NOKEY
+tracking_system: file-system
+story_location: _bmad-output/implementation-artifacts
+
+development_status:
+  epic-1: in-progress
+  1-1-project-initialization-and-authentication-via-google-oauth2: done
+  1-1a-stateless-jwt-with-redis-denylist-and-bloom-filters: done
+  1-1b-e2e-test-for-oauth2-login-flow: done
+  1-2-localization-and-translation-architecture: backlog
+  1-3-automatic-profile-generation-and-first-entry: ready-for-dev
+  1-4-profile-management-in-personal-cabinet: backlog
+  1-5-account-deletion-with-anonymization: backlog
+  1-6-avatar-selection-and-management: backlog
+  1-7-onboarding-tutorial: backlog
+  epic-1-retrospective: optional
+  epic-2: backlog
+  2-1-rule-system-selection-and-inline-creation: backlog
+  2-2-match-type-and-player-selection-portrait: backlog
+  2-3-score-entry-and-automatic-completion: backlog
+  2-4-match-submission-with-undo-window: backlog
+  2-5-position-swapping-between-games: backlog
+  epic-2-retrospective: optional
+  epic-3: backlog
+  3-1-confirmation-requests-and-push-notifications: backlog
+  3-2-single-tap-confirmation-with-undo-window: backlog
+  3-3-match-rejection-with-reason: backlog
+  3-4-context-aware-verification-rules: backlog
+  3-5-publication-rules-and-24-hour-cooldown: backlog
+  3-6-submission-rate-limiting-anti-spam: backlog
+  epic-3-retrospective: optional
+  epic-4: backlog
+  4-1-empty-state-and-demo-data: backlog
+  4-2-global-leaderboard-with-filtering: backlog
+  4-3-positional-statistics-attack-vs-defense: backlog
+  4-4-team-pair-statistics: backlog
+  4-5-head-to-head-h2h-comparison: backlog
+  4-6-unified-match-history-my-matches: backlog
+  epic-4-retrospective: optional
+  epic-5: backlog
+  5-1-real-time-scoring-interface-landscape: backlog
+  5-2-live-activity-timeline-and-undo: backlog
+  5-3-live-position-swapping: backlog
+  5-4-third-party-referee-mode: backlog
+  5-5-screen-wake-lock-and-continuity: backlog
+  epic-5-retrospective: optional
+  epic-6: backlog
+  6-1-named-player-groups-teams: backlog
+  6-2-default-team-and-rule-template: backlog
+  6-3-create-want-to-play-pool: backlog
+  6-4-join-existing-pool: backlog
+  6-5-pool-notifications: backlog
+  6-6-challenge-player-or-group: backlog
+  epic-6-retrospective: optional
+  epic-7: backlog
+  7-1-achievement-system-badges: backlog
+  7-2-humorous-anti-achievements: backlog
+  7-3-award-wall-and-progress-tracking: backlog
+  7-4-narrative-match-broadcasts: backlog
+  7-5-auto-generated-statistical-insights: backlog
+  epic-7-retrospective: optional
+  epic-8: backlog
+  8-1-tournament-creation-and-configuration: backlog
+  8-2-team-registration-and-confirmation: backlog
+  8-3-automated-bracket-generation-and-seeding: backlog
+  8-4-equal-match-distribution-2v2-random-pairing: backlog
+  8-5-asynchronous-tournament-match-execution: backlog
+  8-6-tournament-rule-system-enforcement: backlog
+  8-7-tournament-standings-and-archive: backlog
+  8-8-tournament-confirmation-deadline: backlog
+  epic-8-retrospective: optional


### PR DESCRIPTION
## Summary

- Creates comprehensive story file for Story 1.3 (Automatic Profile Generation & First Entry)
- Updates sprint-status.yaml: `1-3-automatic-profile-generation-and-first-entry` → `ready-for-dev`

Closes #8

## Story Scope

**Backend:** Add `nickname` + `@Version` to `User` entity; update `UserService.findOrCreate()` to set `nickname = emailPrefix(email)` and `avatar = "placeholder"` on first login; expose `GET /api/v1/users/me`.

**Frontend:** Pinia `useProfileStore` + `profileApi.ts` in `features/profile/`; update `HomeHub.vue` to display nickname; placeholder avatar SVG fallback.

**Key dev guardrails documented:**
- `@Version Long` (not primitive) mandatory per write rules — currently MISSING from `User.java`
- Package is `com.tictactore` (not `com.itemis.tictactore` as in planning docs)
- Spring Boot is 3.4.5 (not 4.0 as in planning docs)
- Race-condition guard in `findOrCreate` must be preserved

## Test plan

- [ ] `UserServiceTest`: nickname = email prefix on create; avatar = "placeholder" on create; returning user preserves profile; malformed email throws
- [ ] `UserControllerIT`: authenticated `GET /api/v1/users/me` → 200; unauthenticated → 401
- [ ] Frontend Vitest: `profileStore` state populated after `fetchProfile()`
- [ ] `./scripts/ci-local.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)