### PR TITLE
fix: load .env file as properties source for local development

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,8 @@ spring:
             scope:
               - email
               - profile
+  config:
+    import: optional:file:.env[.properties]
 
 application:
   security:


### PR DESCRIPTION
Add spring.config.import with [.properties] format hint so Spring Boot correctly parses the .env file and resolves TTT_* placeholders locally. The optional: prefix ensures production environments (where .env is absent) continue to use OS environment variables without error.