### PR TITLE
🧹 [Replace RuntimeException with IllegalStateException in UserService]

### DIFF
--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -134,7 +134,7 @@ public class UserService {
             byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
             return properties.getAvatar().getApiUrl() + HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 algorithm not found", e);
+            throw new IllegalStateException("SHA-256 algorithm not found", e);
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Replaced the generic `RuntimeException` with `IllegalStateException` in the `generateDeterministicAvatar` method's `catch (NoSuchAlgorithmException e)` block within `UserService.java`.

💡 **Why:** Throwing a generic `RuntimeException` is an anti-pattern that can obscure the true cause of a failure and makes catching specific issues harder. An `IllegalStateException` is more appropriate here because the lack of the SHA-256 algorithm (which is guaranteed to exist by the Java platform specification) indicates a deeply flawed or invalid JVM state.

✅ **Verification:** Verified by running the full backend test suite via `./mvnw test`, which executed 44 tests with 0 failures and 0 errors, confirming that the change causes no regressions.

✨ **Result:** Improved codebase maintainability by using more descriptive and standard exception types for invalid states without altering functionality.

---
*PR created automatically by Jules for task [17480233599293118443](https://jules.google.com/task/17480233599293118443) started by @phalbohr*