### PR TITLE
🧪 [testing improvement] Add unit tests for CookieUtils

### DIFF
--- a/src/test/java/com/tictactore/util/CookieUtilsTest.java
+++ b/src/test/java/com/tictactore/util/CookieUtilsTest.java
@@ -1,0 +1,33 @@
+package com.tictactore.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CookieUtils Tests")
+class CookieUtilsTest {
+
+    private static final String TEST_NAME = "test-cookie";
+    private static final String TEST_VALUE = "test-value";
+    private static final boolean IS_SECURE = true;
+    private static final boolean IS_HTTP_ONLY = true;
+    private static final Duration MAX_AGE = Duration.ofDays(1);
+    private static final String EXPECTED_PATH = "/";
+    private static final String EXPECTED_SAME_SITE = "Lax";
+
+    @Test
+    @DisplayName("buildCookie - should construct ResponseCookie with expected attributes")
+    void shouldConstructCookieWithExpectedAttributes() {
+        var result = CookieUtils.buildCookie(TEST_NAME, TEST_VALUE, IS_SECURE, IS_HTTP_ONLY, MAX_AGE);
+
+        assertThat(result.getName()).isEqualTo(TEST_NAME);
+        assertThat(result.getValue()).isEqualTo(TEST_VALUE);
+        assertThat(result.isSecure()).isEqualTo(IS_SECURE);
+        assertThat(result.isHttpOnly()).isEqualTo(IS_HTTP_ONLY);
+        assertThat(result.getMaxAge()).isEqualTo(MAX_AGE);
+        assertThat(result.getPath()).isEqualTo(EXPECTED_PATH);
+        assertThat(result.getSameSite()).isEqualTo(EXPECTED_SAME_SITE);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `CookieUtils` class, which handles the logic for constructing Spring `ResponseCookie` objects (specifically for the `/` path and `Lax` SameSite policy), lacked unit tests.

📊 **Coverage:** What scenarios are now tested
*   Verification that all provided arguments (name, value, secure, httpOnly, maxAge) correctly bind to the resulting `ResponseCookie`.
*   Verification that the static internal default values (path `/` and sameSite `Lax`) are applied properly.

✨ **Result:** The improvement in test coverage
The `CookieUtils` class now has 100% test coverage, ensuring future modifications to cookie defaults or properties won't regress silently.

---
*PR created automatically by Jules for task [3012464958307077779](https://jules.google.com/task/3012464958307077779) started by @phalbohr*