### PR TITLE
🧪 Add unit tests for UserRepository

### DIFF
--- a/src/test/java/com/tictactore/repository/UserRepositoryTest.java
+++ b/src/test/java/com/tictactore/repository/UserRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.tictactore.repository;
+
+import com.tictactore.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@DisplayName("UserRepository Tests")
+class UserRepositoryTest {
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_NICKNAME = "testnick";
+    private static final String NON_EXISTENT_EMAIL = "none@example.com";
+    private static final String NON_EXISTENT_NICKNAME = "nonenick";
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("findByEmail - should return user when email exists")
+    void findByEmail_ReturnsUser() {
+        var user = User.builder()
+                .email(TEST_EMAIL)
+                .nickname(TEST_NICKNAME)
+                .build();
+        userRepository.save(user);
+
+        var result = userRepository.findByEmail(TEST_EMAIL);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo(TEST_EMAIL);
+    }
+
+    @Test
+    @DisplayName("findByEmail - should return empty when email does not exist")
+    void findByEmail_ReturnsEmpty() {
+        var result = userRepository.findByEmail(NON_EXISTENT_EMAIL);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("existsByNickname - should return true when nickname exists")
+    void existsByNickname_ReturnsTrue() {
+        var user = User.builder()
+                .email(TEST_EMAIL)
+                .nickname(TEST_NICKNAME)
+                .build();
+        userRepository.save(user);
+
+        var result = userRepository.existsByNickname(TEST_NICKNAME);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByNickname - should return false when nickname does not exist")
+    void existsByNickname_ReturnsFalse() {
+        var result = userRepository.existsByNickname(NON_EXISTENT_NICKNAME);
+
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the custom JPA query methods in `UserRepository`.
📊 **Coverage:** Added `@DataJpaTest` covering `findByEmail` and `existsByNickname` for both positive (data exists) and negative (data doesn't exist) scenarios. The tests use the Arrange-Act-Assert structure and strictly adhere to the project's zero-comment and `@DisplayName` policies.
✨ **Result:** The `UserRepository` now has 100% test coverage for its custom methods, providing a reliable safety net against query regressions.

---
*PR created automatically by Jules for task [12643009299819569757](https://jules.google.com/task/12643009299819569757) started by @phalbohr*