### PR TITLE
🐛 [AvatarPicker] Fix Shift+Tab focus trap leak

### DIFF
--- a/frontend/src/components/AvatarPicker.vue
+++ b/frontend/src/components/AvatarPicker.vue
@@ -44,7 +44,7 @@ function handleKeyDown(event: KeyboardEvent) {
       firstElement.focus()
       event.preventDefault()
     } else if (event.shiftKey) {
-      if (document.activeElement === firstElement) {
+      if (document.activeElement === firstElement || document.activeElement === modalRef.value) {
         lastElement.focus()
         event.preventDefault()
       }

--- a/frontend/src/components/__tests__/AvatarPicker.spec.ts
+++ b/frontend/src/components/__tests__/AvatarPicker.spec.ts
@@ -52,4 +52,34 @@ describe('AvatarPicker', () => {
 
     expect(wrapper.emitted('close')).toBeTruthy()
   })
+
+  it('handles Shift+Tab correctly when modal container is focused', async () => {
+    const wrapper = mount(AvatarPicker, {
+      global: { plugins: [testI18n] },
+      attachTo: document.body
+    })
+
+    const modalRef = wrapper.find('[data-testid="avatar-picker-backdrop"]')
+    const cancelBtn = wrapper.find('[data-testid="cancel-picker-button"]')
+
+    // Focus the modal container
+    ;(modalRef.element as HTMLElement).focus()
+    expect(document.activeElement).toBe(modalRef.element)
+
+    // Simulate Shift+Tab
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+
+    // dispatch event on the window, since event listener is attached to window
+    window.dispatchEvent(event)
+
+    // Focus should be moved to the last focusable element (cancel button)
+    expect(document.activeElement).toBe(cancelBtn.element)
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
🎯 What
Fixed a bug in the `AvatarPicker` component where the modal's focus trap could be bypassed via Shift+Tab. When the modal opens without a selected avatar, focus is placed on the modal container (`modalRef`). If the user immediately presses Shift+Tab, the focus evaluation failed to match `firstElement`, skipping `event.preventDefault()` and leaking focus out of the modal into the background DOM.

📊 Coverage
Added a unit test `handles Shift+Tab correctly when modal container is focused` in `AvatarPicker.spec.ts` that explicitly mounts the component, focuses the modal container, and dispatches a Shift+Tab `keydown` event to assert that focus correctly wraps to the last focusable element (the cancel button).

✨ Result
The focus trap is now robust and prevents keyboard navigation from escaping the modal dialogue when moving backward from the container element itself.

---
*PR created automatically by Jules for task [7345544321635499273](https://jules.google.com/task/7345544321635499273) started by @phalbohr*