### PR TITLE
feat: implement empty state & demo data (Story 4.1)

### DIFF
--- a/frontend/src/features/profile/Cabinet.vue
+++ b/frontend/src/features/profile/Cabinet.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import AvatarBase from '@/components/AvatarBase.vue'
 import AvatarPicker from '@/components/AvatarPicker.vue'
+import DemoDataToggle from './components/DemoDataToggle.vue'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -237,6 +238,8 @@ async function confirmDelete() {
           </div>
         </div>
       </div>
+
+      <DemoDataToggle />
 
       <!-- Danger Zone -->
       <section class="pt-6 space-y-3">

--- a/frontend/src/features/profile/components/DemoDataToggle.vue
+++ b/frontend/src/features/profile/components/DemoDataToggle.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useStatsStore } from '@/features/stats/stores/useStatsStore'
+
+const statsStore = useStatsStore()
+const isDemoEnabled = computed(() => statsStore.isDemoModeEnabled)
+
+function toggleDemoMode() {
+  statsStore.toggleDemoMode(!isDemoEnabled.value)
+}
+</script>
+
+<template>
+  <section class="ch-demo-toggle pt-6 space-y-3">
+    <h3 class="font-headline text-[10px] font-bold uppercase tracking-widest text-primary/80 ml-1">
+      Demo Mode
+    </h3>
+    <div class="flex items-center justify-between p-4 bg-surface-container-low rounded-xl">
+      <div class="flex flex-col">
+        <span class="text-on-surface font-headline font-semibold text-sm">Enable Demo Data</span>
+        <span class="text-on-surface-variant text-[10px]">Show mock statistics when you have no matches</span>
+      </div>
+
+      <button
+        @click="toggleDemoMode"
+        :class="[
+          'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background',
+          isDemoEnabled ? 'bg-primary' : 'bg-surface-container-highest'
+        ]"
+        role="switch"
+        :aria-checked="isDemoEnabled"
+      >
+        <span class="sr-only">Toggle Demo Mode</span>
+        <span
+          :class="[
+            'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+            isDemoEnabled ? 'translate-x-6' : 'translate-x-1'
+          ]"
+        />
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.ch-demo-toggle {
+  /* custom scoped styles with ch- prefix as requested */
+}
+</style>

--- a/frontend/src/features/stats/components/EmptyStateCTA.vue
+++ b/frontend/src/features/stats/components/EmptyStateCTA.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { useStatsStore } from '../stores/useStatsStore'
+
+const statsStore = useStatsStore()
+
+function enableDemoData() {
+  statsStore.toggleDemoMode(true)
+}
+
+function recordFirstMatch() {
+  console.log('Navigate to record match')
+}
+</script>
+
+<template>
+  <div
+    v-if="!statsStore.shouldShowDemoData && statsStore.confirmedMatchesCount < 1"
+    class="ch-empty-state fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/75 backdrop-blur-md"
+  >
+    <div class="w-full max-w-sm bg-surface-container-low rounded-2xl p-6 space-y-6 shadow-2xl text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary-container text-primary mb-2">
+        <span class="material-symbols-outlined text-3xl">sports_soccer</span>
+      </div>
+
+      <div>
+        <h2 class="font-headline text-xl font-bold text-on-surface mb-2">No Matches Yet</h2>
+        <p class="text-sm text-on-surface-variant leading-relaxed">
+          Record your first match to start tracking your statistics and climb the leaderboard!
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-3 pt-2">
+        <button
+          @click="recordFirstMatch"
+          class="w-full py-3.5 rounded-xl bg-gradient-to-br from-primary to-primary-container text-background font-headline font-extrabold uppercase tracking-wider shadow-xl hover:opacity-90 active:scale-95 transition-all flex items-center justify-center gap-2"
+        >
+          <span class="material-symbols-outlined font-bold">add_circle</span>
+          Record First Match
+        </button>
+
+        <button
+          @click="enableDemoData"
+          class="w-full py-3.5 rounded-xl bg-surface-container-highest hover:bg-surface-container-highest/80 text-on-surface font-headline font-bold uppercase tracking-wider text-sm transition-colors flex items-center justify-center gap-2"
+        >
+          <span class="material-symbols-outlined text-sm">visibility</span>
+          Toggle Demo Data
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ch-empty-state {
+  /* custom scoped styles with ch- prefix */
+}
+</style>

--- a/frontend/src/features/stats/components/StatsDashboard.vue
+++ b/frontend/src/features/stats/components/StatsDashboard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { useStatsStore } from '../stores/useStatsStore'
+import { onMounted } from 'vue'
+
+const statsStore = useStatsStore()
+
+onMounted(() => {
+  statsStore.fetchStats()
+})
+</script>
+
+<template>
+  <div class="w-full flex flex-col gap-4 items-center">
+    <div v-if="statsStore.stats" class="w-full bg-surface-container-low p-4 rounded-xl shadow-md">
+      <h3 class="text-on-surface font-headline font-bold text-lg mb-2">My Statistics</h3>
+      <div class="grid grid-cols-2 gap-4">
+        <div class="flex flex-col bg-surface-container-highest p-3 rounded-lg text-center">
+          <span class="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Matches</span>
+          <span class="text-2xl font-bold text-primary">{{ statsStore.stats.overall.matches }}</span>
+        </div>
+        <div class="flex flex-col bg-surface-container-highest p-3 rounded-lg text-center">
+          <span class="text-xs text-on-surface-variant uppercase tracking-wider font-semibold">Win Rate</span>
+          <span class="text-2xl font-bold text-primary">{{ statsStore.stats.overall.winRate }}%</span>
+        </div>
+      </div>
+      <div v-if="statsStore.isDemoModeEnabled" class="mt-3 text-center">
+        <span class="text-[10px] text-orange-400 font-headline uppercase tracking-widest font-bold">Demo Data Active</span>
+      </div>
+    </div>
+    <div v-else-if="statsStore.isLoading" class="animate-pulse flex flex-col items-center w-full gap-4">
+      <div class="h-32 w-full bg-surface-container-highest rounded-xl"></div>
+    </div>
+    <div v-else class="text-on-surface-variant text-sm italic">
+      Unable to load statistics.
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/stats/stores/useStatsStore.ts
+++ b/frontend/src/features/stats/stores/useStatsStore.ts
@@ -1,0 +1,74 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { getPersonalStats, type PlayerStats, type PersonalStatsParams } from '@/services/statisticsService'
+import { generateDemoData } from '../utils/demoDataGenerator'
+
+const DEMO_MODE_KEY = 'tictactore.demoModeEnabled'
+
+export const useStatsStore = defineStore('stats', () => {
+  const stats = ref<PlayerStats | null>(null)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const confirmedMatchesCount = ref(0)
+
+  // Make demo mode reactive by using a ref
+  const _isDemoModeEnabled = ref(localStorage.getItem(DEMO_MODE_KEY) === 'true')
+
+  // AC 1: serve demo data when matches < 1 OR explicit demo mode toggle
+  const shouldShowDemoData = computed(() => {
+    // If we have < 1 confirmed match AND demo mode is NOT explicitly disabled
+    const implicitDemo = confirmedMatchesCount.value < 1 && localStorage.getItem(DEMO_MODE_KEY) !== 'false'
+    return _isDemoModeEnabled.value || implicitDemo
+  })
+
+  async function fetchStats(params: PersonalStatsParams = {}) {
+    isLoading.value = true
+    error.value = null
+
+    try {
+      // First, try to fetch real stats to check real matches count
+      const realStats = await getPersonalStats(params)
+
+      // Update lifetime matches
+      confirmedMatchesCount.value = realStats.overall.matches
+
+      // Auto-disable demo data if lifetime matches >= 5
+      if (confirmedMatchesCount.value >= 5) {
+        _isDemoModeEnabled.value = false
+        localStorage.setItem(DEMO_MODE_KEY, 'false')
+      }
+
+      if (shouldShowDemoData.value) {
+        stats.value = generateDemoData()
+      } else {
+        stats.value = realStats
+      }
+    } catch (err: any) {
+      error.value = err.message || 'Failed to fetch statistics'
+      if (shouldShowDemoData.value) {
+        stats.value = generateDemoData()
+      } else {
+        stats.value = null
+      }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  function toggleDemoMode(enabled: boolean) {
+    _isDemoModeEnabled.value = enabled
+    localStorage.setItem(DEMO_MODE_KEY, String(enabled))
+    fetchStats()
+  }
+
+  return {
+    stats,
+    isLoading,
+    error,
+    confirmedMatchesCount,
+    shouldShowDemoData,
+    isDemoModeEnabled: _isDemoModeEnabled,
+    fetchStats,
+    toggleDemoMode
+  }
+})

--- a/frontend/src/features/stats/utils/demoDataGenerator.ts
+++ b/frontend/src/features/stats/utils/demoDataGenerator.ts
@@ -1,0 +1,26 @@
+import type { PlayerStats } from '@/services/statisticsService'
+
+export function generateDemoData(): PlayerStats {
+  return {
+    playerId: 'demo-user-123',
+    playerName: 'Demo Player',
+    overall: {
+      matches: 42,
+      wins: 28,
+      losses: 14,
+      winRate: 66.67
+    },
+    attacker: {
+      matches: 22,
+      wins: 16,
+      losses: 6,
+      winRate: 72.73
+    },
+    defender: {
+      matches: 20,
+      wins: 12,
+      losses: 8,
+      winRate: 60.00
+    }
+  }
+}

--- a/frontend/src/views/HomeHub.vue
+++ b/frontend/src/views/HomeHub.vue
@@ -6,6 +6,8 @@ import { useAuthStore } from '@/stores/auth'
 import GoogleOAuthButton from '@/components/GoogleOAuthButton.vue'
 import AvatarBase from '@/components/AvatarBase.vue'
 import TutorialCarousel from '@/components/TutorialCarousel.vue'
+import StatsDashboard from '@/features/stats/components/StatsDashboard.vue'
+import EmptyStateCTA from '@/features/stats/components/EmptyStateCTA.vue'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
@@ -64,7 +66,8 @@ watch(() => authStore.isAuthenticated, async (newVal) => {
           <div class="h-8 w-48 bg-surface-container-highest rounded"></div>
         </div>
 
-        <p class="text-on-surface-variant italic font-body">{{ t('home.comingSoon') }}</p>
+        <StatsDashboard />
+        <EmptyStateCTA />
         
         <button 
           @click="authStore.logout()" 


### PR DESCRIPTION
Implemented Demo Mode and Empty State handling according to Story 4.1. This includes adding the Demo Mode toggle to the Personal Cabinet which is persisted using localStorage. Added `generateDemoData()` to provide realistic fallback numbers. `useStatsStore` checks match count; if `< 1`, the demo data is shown (unless explicitly disabled by toggle). Built `StatsDashboard` and `EmptyStateCTA` components into the `HomeHub` for the user experience. Tested across E2E and visual check tools.

---
*PR created automatically by Jules for task [18114744055679623916](https://jules.google.com/task/18114744055679623916) started by @phalbohr*