### PR TITLE
⚡ [Fix Inefficient Nickname Collision Resolution]

### DIFF
--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -122,35 +122,35 @@ public class UserService {
         }
         String nickname = baseNickname;
 
-        int attempts = 0;
-        while (userRepository.existsByNickname(nickname) && attempts < MAX_NICKNAME_ATTEMPTS) {
-            nickname = baseNickname + String.format("%04d", random.nextInt(10000));
-            attempts++;
+        if (!userRepository.existsByNickname(nickname)) {
+            return nickname;
         }
 
-        if (attempts >= MAX_NICKNAME_ATTEMPTS) {
-            List<String> candidates = new ArrayList<>();
-            for (int i = 0; i < MAX_NICKNAME_ATTEMPTS; i++) {
-                candidates.add(baseNickname + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8));
-            }
-
-            List<String> existing = userRepository.findExistingNicknames(candidates);
-
-            String selectedFallback = null;
-            for (String candidate : candidates) {
-                if (!existing.contains(candidate)) {
-                    selectedFallback = candidate;
-                    break;
-                }
-            }
-            
-            if (selectedFallback == null) {
-                throw new IllegalStateException("Failed to generate unique nickname after fallback attempts");
-            }
-            nickname = selectedFallback;
+        List<String> suffixCandidates = new ArrayList<>();
+        for (int i = 0; i < MAX_NICKNAME_ATTEMPTS; i++) {
+            suffixCandidates.add(baseNickname + String.format("%04d", random.nextInt(10000)));
         }
 
-        return nickname;
+        List<String> existingSuffixes = userRepository.findExistingNicknames(suffixCandidates);
+        for (String candidate : suffixCandidates) {
+            if (!existingSuffixes.contains(candidate)) {
+                return candidate;
+            }
+        }
+
+        List<String> fallbackCandidates = new ArrayList<>();
+        for (int i = 0; i < MAX_NICKNAME_ATTEMPTS; i++) {
+            fallbackCandidates.add(baseNickname + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8));
+        }
+
+        List<String> existingFallbacks = userRepository.findExistingNicknames(fallbackCandidates);
+        for (String candidate : fallbackCandidates) {
+            if (!existingFallbacks.contains(candidate)) {
+                return candidate;
+            }
+        }
+
+        throw new IllegalStateException("Failed to generate unique nickname after fallback attempts");
     }
 
     private String generateDeterministicAvatar(String email) {

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -151,7 +151,7 @@ class UserServiceTest {
     void shouldHandleNicknameCollision() {
         when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());
         when(userRepository.existsByNickname("new")).thenReturn(true);
-        when(userRepository.existsByNickname(argThat(s -> s != null && !s.equals("new")))).thenReturn(false);
+        when(userRepository.findExistingNicknames(anyList())).thenReturn(java.util.Collections.emptyList());
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
         User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
@@ -233,7 +233,14 @@ class UserServiceTest {
     @DisplayName("Nickname Collision - should use UUID fallback after max attempts")
     void shouldHandleNicknameCollisionExhaustion() {
         when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());
-        when(userRepository.existsByNickname(anyString())).thenReturn(true, true, true, true, true, true, true, true, true, true, true, false);
+        when(userRepository.existsByNickname("new")).thenReturn(true);
+        when(userRepository.findExistingNicknames(anyList())).thenAnswer(inv -> {
+            java.util.List<String> args = inv.getArgument(0);
+            if (!args.isEmpty() && args.get(0).length() <= "new".length() + 4) {
+                return new java.util.ArrayList<>(args);
+            }
+            return java.util.Collections.emptyList();
+        });
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
         User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);


### PR DESCRIPTION
💡 What: Refactored `generateUniqueNickname` in `UserService` to evaluate collision candidates in bulk instead of sequential 1-by-1 queries inside a loop.
🎯 Why: Mitigate potential N+1 query issues during User Registration where high collision likelihoods on default nicknames led to up to 10 separate synchronization round-trips.
📊 Measured Improvement: Database query counts in the case of exhaustive nickname collisions have been reduced from O(n) roundtrips (where n <= 10) down to exactly O(1) bulk query roundtrips.

---
*PR created automatically by Jules for task [9238527026367023429](https://jules.google.com/task/9238527026367023429) started by @phalbohr*