### PR TITLE
Fix over-engineered transaction boundary in UserCreator

### DIFF
--- a/src/main/java/com/tictactore/service/UserCreator.java
+++ b/src/main/java/com/tictactore/service/UserCreator.java
@@ -13,7 +13,7 @@ public class UserCreator {
 
     private final UserRepository userRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRED)
     public User createUser(User user) {
         return userRepository.save(user);
     }


### PR DESCRIPTION
Fix over-engineered transaction boundary in UserCreator. Replaced `@Transactional(propagation = Propagation.REQUIRES_NEW)` with `@Transactional(propagation = Propagation.REQUIRED)` in `UserCreator` to fix the issue of using `REQUIRES_NEW` without an active parent transaction. This aligns with standard business logic propagation rules.

---
*PR created automatically by Jules for task [14975922564947498563](https://jules.google.com/task/14975922564947498563) started by @phalbohr*