### PR TITLE
🧹 [fix missing null check in generateUniqueNickname]

### DIFF
--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -115,6 +115,10 @@ public class UserService {
     }
 
     private String generateUniqueNickname(String email) {
+        if (email == null) {
+            throw new IllegalArgumentException("Email cannot be null");
+        }
+
         String prefix = email.split("@")[0];
         String baseNickname = sanitizeNickname(prefix);
         if (baseNickname.isEmpty()) {

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -98,6 +98,16 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("findOrCreate - should throw exception when email is null")
+    void findOrCreate_shouldThrowException_whenEmailIsNull() {
+        when(userRepository.findByEmail(null)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.findOrCreate(null, "provider123"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Email cannot be null");
+    }
+
+    @Test
     @DisplayName("Provider Mismatch - should throw BadCredentialsException to prevent account takeover")
     void findOrCreate_throwsException_whenEmailFoundButProviderMismatch() {
         var existing = User.builder()


### PR DESCRIPTION
🎯 What
Added a missing null check for the `email` parameter in the `generateUniqueNickname` method of `UserService`.

💡 Why
Without this check, passing a null email causes a `NullPointerException` during the `split("@")` operation, which is harder to debug and not as explicit as an `IllegalArgumentException`.

✅ Verification
Ran the unit tests with `./mvnw test` to ensure no regressions were introduced.

✨ Result
The application now explicitly throws an `IllegalArgumentException` with the message "Email cannot be null" if a null email is provided to `findOrCreate`, making the error handling clearer and preventing unexpected NPEs.

---
*PR created automatically by Jules for task [2290073972185323218](https://jules.google.com/task/2290073972185323218) started by @phalbohr*