### PR TITLE
🧹 fix: use UserNotFoundException for missing user lookups

### DIFF
--- a/src/main/java/com/tictactore/exception/UserNotFoundException.java
+++ b/src/main/java/com/tictactore/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.tictactore.exception;
+
+public class UserNotFoundException extends ResourceNotFoundException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -74,7 +74,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public User getProfile(UUID userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+                .orElseThrow(() -> new com.tictactore.exception.UserNotFoundException("User not found"));
     }
 
     private User createNewUser(String email, String providerId) {
@@ -167,7 +167,7 @@ public class UserService {
     @Transactional
     public User updateProfile(UUID userId, UpdateProfileRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+                .orElseThrow(() -> new com.tictactore.exception.UserNotFoundException("User not found"));
 
         if (request.getNickname() != null && !request.getNickname().trim().isEmpty()) {
             String sanitized = sanitizeNickname(request.getNickname());
@@ -222,7 +222,7 @@ public class UserService {
             throw new IllegalArgumentException("User ID cannot be null");
         }
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+                .orElseThrow(() -> new com.tictactore.exception.UserNotFoundException("User not found"));
 
         if (user.getProviderId() == null && "anonymous".equals(user.getAvatar())) {
             return;

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -214,7 +214,7 @@ class UserServiceTest {
         when(userRepository.findById(id)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.getProfile(id))
-                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+                .isInstanceOf(com.tictactore.exception.UserNotFoundException.class)
                 .hasMessageContaining("User not found");
     }
 
@@ -345,7 +345,7 @@ class UserServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.deleteAccount(userId))
-                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+                .isInstanceOf(com.tictactore.exception.UserNotFoundException.class)
                 .hasMessageContaining("User not found");
     }
 


### PR DESCRIPTION
🎯 What
Replaced `ResourceNotFoundException` with a specific `UserNotFoundException` (which extends it) in `UserService` for missing user lookups.

💡 Why
This improves the semantic clarity of the service layer exceptions, differentiating missing user cases from other potential missing resources, while keeping the 404 API behavior intact (as `GlobalExceptionHandler` already handles the parent class). This addresses the deferred work item DW-17.

✅ Verification
- Code compiles.
- Backend tests (`./mvnw test`) pass.
- Verified test assertions correctly expect `UserNotFoundException.class`.

✨ Result
Cleaner semantics in the backend codebase for user retrieval operations.

---
*PR created automatically by Jules for task [13925093862294371054](https://jules.google.com/task/13925093862294371054) started by @phalbohr*