### PR TITLE
🧹 [resolve high collision probability in nickname suffix]

### DIFF
--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -124,7 +124,7 @@ public class UserService {
 
         int attempts = 0;
         while (userRepository.existsByNickname(nickname) && attempts < MAX_NICKNAME_ATTEMPTS) {
-            nickname = baseNickname + String.format("%04d", random.nextInt(10000));
+            nickname = baseNickname + String.format("%08d", random.nextInt(100_000_000));
             attempts++;
         }
 

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -68,6 +68,18 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("findOrCreate - should use 8-digit suffix when base nickname is taken")
+    void findOrCreate_shouldUse8DigitSuffix_whenBaseNicknameIsTaken() {
+        when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname("new")).thenReturn(true).thenReturn(false);
+        when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
+
+        assertThat(user.getNickname()).matches("new\\d{8}");
+    }
+
+    @Test
     @DisplayName("Create User - should save and return new user when email not found")
     void findOrCreate_createsNewUser_whenEmailNotFound() {
         when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());
@@ -157,7 +169,7 @@ class UserServiceTest {
         User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
 
         assertThat(user.getNickname()).startsWith("new");
-        assertThat(user.getNickname()).hasSize(7);
+        assertThat(user.getNickname()).hasSize(11);
     }
 
     @Test


### PR DESCRIPTION
🎯 What
Increased the nickname suffix from a 4-digit number (bound: 10,000) to an 8-digit number (bound: 100,000,000). 
Updated tests in `UserServiceTest` to expect an 11 character length instead of 7 when a fallback nickname is used, and added a specific test to assert the 8-digit suffix fallback behavior (`new\d{8}`).

💡 Why
To drastically reduce the database unique constraint violation failures (DataIntegrityViolationException) for common nicknames when the base nickname is already taken, leading to better resilience on user creation.

✅ Verification
Ran the entire test suite `mvnw test`. All 61 tests, including the updated/new unit tests for UserService, passed successfully without regressions.

✨ Result
A significantly lower probability of high-collision rate in generated nicknames during the automatic profile generation fallback path.

---
*PR created automatically by Jules for task [2799777723062062249](https://jules.google.com/task/2799777723062062249) started by @phalbohr*