### PR TITLE
🧹 [Security configuration: Use origin patterns for CORS]

### DIFF
--- a/src/main/java/com/tictactore/config/SecurityConfig.java
+++ b/src/main/java/com/tictactore/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
     @Bean
     public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
         org.springframework.web.cors.CorsConfiguration configuration = new org.springframework.web.cors.CorsConfiguration();
-        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedOriginPatterns(allowedOrigins);
         configuration.setAllowedMethods(java.util.Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"));
         configuration.setAllowedHeaders(java.util.Arrays.asList("Authorization", "Cache-Control", "Content-Type", "X-XSRF-TOKEN", "X-Requested-With", "Accept", "Origin"));
         configuration.setAllowCredentials(true);

--- a/src/test/java/com/tictactore/config/SecurityConfigTest.java
+++ b/src/test/java/com/tictactore/config/SecurityConfigTest.java
@@ -1,0 +1,63 @@
+package com.tictactore.config;
+
+import com.tictactore.security.CsrfCookieFilter;
+import com.tictactore.security.CustomOAuth2SuccessHandler;
+import com.tictactore.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SecurityConfig Tests")
+class SecurityConfigTest {
+
+    @Mock
+    private CustomOAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Mock
+    private JwtAuthenticationFilter jwtAuthFilter;
+
+    @Mock
+    private CsrfCookieFilter csrfCookieFilter;
+
+    @Mock
+    private Environment env;
+
+    @InjectMocks
+    private SecurityConfig securityConfig;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(securityConfig, "allowedOrigins", List.of("http://localhost:3000", "https://prod.com"));
+    }
+
+    @Test
+    @DisplayName("corsConfigurationSource - should configure allowedOriginPatterns instead of allowedOrigins for production credentials safety")
+    void shouldConfigureCorsWithOriginPatterns() {
+        var source = securityConfig.corsConfigurationSource();
+        var request = new MockHttpServletRequest();
+        request.setMethod("GET");
+
+        var config = source.getCorsConfiguration(request);
+
+        assertThat(config).isNotNull();
+        assertThat(config.getAllowedOrigins()).isNullOrEmpty();
+        assertThat(config.getAllowedOriginPatterns()).containsExactlyInAnyOrder("http://localhost:3000", "https://prod.com");
+        assertThat(config.getAllowCredentials()).isTrue();
+        assertThat(config.getAllowedMethods()).contains("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH");
+        assertThat(config.getAllowedHeaders()).contains("Authorization", "Cache-Control", "Content-Type", "X-XSRF-TOKEN", "X-Requested-With", "Accept", "Origin");
+    }
+}


### PR DESCRIPTION
🎯 What: Replaced `setAllowedOrigins` with `setAllowedOriginPatterns` in CORS config to properly support dynamic origin settings alongside credentials in production.
💡 Why: The previous setup would fail if wildcards were configured while `allowCredentials` was true. This ensures robust production capability.
✅ Verification: Wrote a unit test to verify that `corsConfigurationSource` correctly delegates to `allowedOriginPatterns` and `allowCredentials`.
✨ Result: The production CORS config limitation described in DW-6 is resolved.

---
*PR created automatically by Jules for task [9209851951875792619](https://jules.google.com/task/9209851951875792619) started by @phalbohr*