### PR TITLE
🐛 [auth store fix: empty nickname validation]

### DIFF
--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '../auth'
+import { useLocaleStore } from '../locale'
+
+vi.mock('../locale', () => ({
+  useLocaleStore: vi.fn(() => ({
+    locale: 'en',
+    setLocale: vi.fn()
+  }))
+}))
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('updateProfile', () => {
+    it('throws error when nickname is empty string', async () => {
+      const store = useAuthStore()
+      store.profile = { nickname: 'old', avatar: '1' }
+
+      await expect(store.updateProfile({ nickname: '' }))
+        .rejects
+        .toThrow('Nickname cannot be empty')
+    })
+
+    it('throws error when nickname is whitespace string', async () => {
+      const store = useAuthStore()
+      store.profile = { nickname: 'old', avatar: '1' }
+
+      await expect(store.updateProfile({ nickname: '   ' }))
+        .rejects
+        .toThrow('Nickname cannot be empty')
+    })
+  })
+})

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -76,10 +76,11 @@ export const useAuthStore = defineStore('auth', () => {
     let finalNickname = nickname
     if (nickname !== undefined) {
       const sanitized = nickname.replace(/[^a-zA-Z0-9]/g, '')
-      if (sanitized.length > 0) {
-        profile.value.nickname = sanitized
-        finalNickname = sanitized
+      if (sanitized.length === 0) {
+        throw new Error('Nickname cannot be empty')
       }
+      profile.value.nickname = sanitized
+      finalNickname = sanitized
     }
     if (language !== undefined) {
       profile.value.language = language


### PR DESCRIPTION
🎯 What
Modified `frontend/src/stores/auth.ts` to explicitly throw an error (`'Nickname cannot be empty'`) when attempting to update a profile with an empty or whitespace-only nickname.

📊 Coverage
Added a new unit test suite `frontend/src/stores/__tests__/auth.spec.ts` that verified the auth store rejects empty and whitespace-only nicknames.

✨ Result
Empty or whitespace-only nicknames are now properly rejected with a clear error rather than being silently ignored, which correctly bubbles up the failure to UI components.

---
*PR created automatically by Jules for task [132669254394254881](https://jules.google.com/task/132669254394254881) started by @phalbohr*