### PR TITLE
🐛 [fix optimistic locking on user updates]

### DIFF
--- a/src/main/java/com/tictactore/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tictactore/exception/GlobalExceptionHandler.java
@@ -10,21 +10,21 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(com.tictactore.exception.ResourceNotFoundException.class)
-    public ResponseEntity<Map<String, String>> handleResourceNotFound(com.tictactore.exception.ResourceNotFoundException e) {
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleResourceNotFound(ResourceNotFoundException e) {
         return ResponseEntity.notFound().build();
     }
 
-    @ExceptionHandler(com.tictactore.exception.ValidationException.class)
-    public ResponseEntity<Map<String, String>> handleValidationException(com.tictactore.exception.ValidationException e) {
-        String msg = e.getMessage() != null ? e.getMessage() : "Invalid input";
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(ValidationException e) {
+        var msg = e.getMessage() != null ? e.getMessage() : "Invalid input";
         return ResponseEntity.badRequest().body(Map.of("message", msg));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException e) {
         var error = e.getBindingResult().getFieldError();
-        String msg = error != null ? error.getDefaultMessage() : "Validation error";
+        var msg = error != null ? error.getDefaultMessage() : "Validation error";
         return ResponseEntity.badRequest().body(Map.of("message", msg != null ? msg : "Validation error"));
     }
 }

--- a/src/main/java/com/tictactore/exception/UserNotFoundException.java
+++ b/src/main/java/com/tictactore/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.tictactore.exception;
+
+public class UserNotFoundException extends ResourceNotFoundException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tictactore/service/UserOperation.java
+++ b/src/main/java/com/tictactore/service/UserOperation.java
@@ -1,0 +1,108 @@
+package com.tictactore.service;
+
+import com.tictactore.annotation.Idempotent;
+import com.tictactore.dto.UpdateProfileRequest;
+import com.tictactore.model.User;
+import com.tictactore.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UserOperation {
+
+    private final UserRepository userRepository;
+    private final Clock clock;
+
+    public String sanitizeNickname(String nickname) {
+        if (nickname == null) {
+            return "";
+        }
+        return nickname.replaceAll("[^a-zA-Z0-9]", "");
+    }
+
+    @Idempotent
+    @Transactional(propagation = Propagation.REQUIRED)
+    public User updateProfile(UUID userId, UpdateProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+
+        if (request.getNickname() != null && !request.getNickname().trim().isEmpty()) {
+            String sanitized = sanitizeNickname(request.getNickname());
+            if (sanitized.isEmpty()) {
+                throw new com.tictactore.exception.ValidationException("Nickname cannot be empty");
+            }
+            if (!sanitized.equals(user.getNickname())) {
+                if (user.getLastNicknameUpdate() != null) {
+                    Instant nextAllowedUpdate = user.getLastNicknameUpdate().plus(30, ChronoUnit.DAYS);
+                    if (Instant.now(clock).isBefore(nextAllowedUpdate)) {
+                        throw new com.tictactore.exception.ValidationException("Nickname can only be changed once every 30 days");
+                    }
+                }
+                if (userRepository.existsByNickname(sanitized)) {
+                    throw new com.tictactore.exception.ValidationException("Nickname already taken");
+                }
+                user.setNickname(sanitized);
+                user.setLastNicknameUpdate(Instant.now(clock));
+            }
+        }
+
+        if (request.getLanguage() != null) {
+            String lang = request.getLanguage().toUpperCase();
+            if (!lang.equals("EN") && !lang.equals("DE")) {
+                throw new com.tictactore.exception.ValidationException("Language must be EN or DE");
+            }
+            user.setLanguage(lang);
+        }
+
+        if (request.getAvatar() != null) {
+            String avatarVal = request.getAvatar().trim();
+            if (!com.tictactore.validation.AvatarValidator.ALLOWED_AVATARS.contains(avatarVal)) {
+                throw new com.tictactore.exception.ValidationException("Invalid avatar selection");
+            }
+            user.setAvatar(avatarVal);
+        }
+
+        if (request.getTutorialCompleted() != null) {
+            user.setTutorialCompleted(request.getTutorialCompleted());
+        }
+
+        try {
+            return userRepository.save(user);
+        } catch (DataIntegrityViolationException e) {
+            throw new com.tictactore.exception.ValidationException("Nickname already taken");
+        }
+    }
+
+    @Idempotent
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void deleteAccount(UUID userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("User ID cannot be null");
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+
+        if (user.getProviderId() == null && "anonymous".equals(user.getAvatar())) {
+            return;
+        }
+
+        UUID uuid = java.util.UUID.randomUUID();
+        user.setEmail("deleted-" + uuid + "@tic-tac-tore.invalid");
+        user.setNickname("ex-player-" + uuid);
+        user.setAvatar("anonymous");
+        user.setProviderId(null);
+        user.setLanguage(null);
+        user.setLastNicknameUpdate(null);
+
+        userRepository.flush();
+    }
+}

--- a/src/main/java/com/tictactore/service/UserOperation.java
+++ b/src/main/java/com/tictactore/service/UserOperation.java
@@ -1,9 +1,11 @@
 package com.tictactore.service;
 
 import com.tictactore.annotation.Idempotent;
-import com.tictactore.dto.UpdateProfileRequest;
+import com.tictactore.exception.UserNotFoundException;
+import com.tictactore.exception.ValidationException;
 import com.tictactore.model.User;
 import com.tictactore.repository.UserRepository;
+import com.tictactore.validation.AvatarValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
@@ -19,10 +21,25 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class UserOperation {
 
+    private static final String ERR_USER_NOT_FOUND = "User not found";
+    private static final String ERR_NICKNAME_EMPTY = "Nickname cannot be empty";
+    private static final String ERR_NICKNAME_COOLDOWN = "Nickname can only be changed once every 30 days";
+    private static final String ERR_NICKNAME_TAKEN = "Nickname already taken";
+    private static final String ERR_LANGUAGE_INVALID = "Language must be EN or DE";
+    private static final String ERR_AVATAR_INVALID = "Invalid avatar selection";
+    private static final String ERR_USER_ID_NULL = "User ID cannot be null";
+    private static final int DAYS_30 = 30;
+    private static final String LANG_EN = "EN";
+    private static final String LANG_DE = "DE";
+    private static final String ANONYMOUS_AVATAR = "anonymous";
+    private static final String DELETED_EMAIL_PREFIX = "deleted-";
+    private static final String EX_PLAYER_PREFIX = "ex-player-";
+    private static final String DELETED_EMAIL_SUFFIX = "@tic-tac-tore.invalid";
+
     private final UserRepository userRepository;
     private final Clock clock;
 
-    public String sanitizeNickname(String nickname) {
+    private String sanitizeNickname(String nickname) {
         if (nickname == null) {
             return "";
         }
@@ -31,54 +48,54 @@ public class UserOperation {
 
     @Idempotent
     @Transactional(propagation = Propagation.REQUIRED)
-    public User updateProfile(UUID userId, UpdateProfileRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+    public User updateProfile(UUID userId, String nickname, String language, String avatar, Boolean tutorialCompleted) {
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(ERR_USER_NOT_FOUND));
 
-        if (request.getNickname() != null && !request.getNickname().trim().isEmpty()) {
-            String sanitized = sanitizeNickname(request.getNickname());
+        if (nickname != null && !nickname.trim().isEmpty()) {
+            var sanitized = sanitizeNickname(nickname);
             if (sanitized.isEmpty()) {
-                throw new com.tictactore.exception.ValidationException("Nickname cannot be empty");
+                throw new ValidationException(ERR_NICKNAME_EMPTY);
             }
             if (!sanitized.equals(user.getNickname())) {
                 if (user.getLastNicknameUpdate() != null) {
-                    Instant nextAllowedUpdate = user.getLastNicknameUpdate().plus(30, ChronoUnit.DAYS);
+                    var nextAllowedUpdate = user.getLastNicknameUpdate().plus(DAYS_30, ChronoUnit.DAYS);
                     if (Instant.now(clock).isBefore(nextAllowedUpdate)) {
-                        throw new com.tictactore.exception.ValidationException("Nickname can only be changed once every 30 days");
+                        throw new ValidationException(ERR_NICKNAME_COOLDOWN);
                     }
                 }
                 if (userRepository.existsByNickname(sanitized)) {
-                    throw new com.tictactore.exception.ValidationException("Nickname already taken");
+                    throw new ValidationException(ERR_NICKNAME_TAKEN);
                 }
                 user.setNickname(sanitized);
                 user.setLastNicknameUpdate(Instant.now(clock));
             }
         }
 
-        if (request.getLanguage() != null) {
-            String lang = request.getLanguage().toUpperCase();
-            if (!lang.equals("EN") && !lang.equals("DE")) {
-                throw new com.tictactore.exception.ValidationException("Language must be EN or DE");
+        if (language != null) {
+            var lang = language.toUpperCase();
+            if (!lang.equals(LANG_EN) && !lang.equals(LANG_DE)) {
+                throw new ValidationException(ERR_LANGUAGE_INVALID);
             }
             user.setLanguage(lang);
         }
 
-        if (request.getAvatar() != null) {
-            String avatarVal = request.getAvatar().trim();
-            if (!com.tictactore.validation.AvatarValidator.ALLOWED_AVATARS.contains(avatarVal)) {
-                throw new com.tictactore.exception.ValidationException("Invalid avatar selection");
+        if (avatar != null) {
+            var avatarVal = avatar.trim();
+            if (!AvatarValidator.ALLOWED_AVATARS.contains(avatarVal)) {
+                throw new ValidationException(ERR_AVATAR_INVALID);
             }
             user.setAvatar(avatarVal);
         }
 
-        if (request.getTutorialCompleted() != null) {
-            user.setTutorialCompleted(request.getTutorialCompleted());
+        if (tutorialCompleted != null) {
+            user.setTutorialCompleted(tutorialCompleted);
         }
 
         try {
             return userRepository.save(user);
         } catch (DataIntegrityViolationException e) {
-            throw new com.tictactore.exception.ValidationException("Nickname already taken");
+            throw new ValidationException(ERR_NICKNAME_TAKEN);
         }
     }
 
@@ -86,19 +103,19 @@ public class UserOperation {
     @Transactional(propagation = Propagation.REQUIRED)
     public void deleteAccount(UUID userId) {
         if (userId == null) {
-            throw new IllegalArgumentException("User ID cannot be null");
+            throw new IllegalArgumentException(ERR_USER_ID_NULL);
         }
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(ERR_USER_NOT_FOUND));
 
-        if (user.getProviderId() == null && "anonymous".equals(user.getAvatar())) {
+        if (user.getProviderId() == null && ANONYMOUS_AVATAR.equals(user.getAvatar())) {
             return;
         }
 
-        UUID uuid = java.util.UUID.randomUUID();
-        user.setEmail("deleted-" + uuid + "@tic-tac-tore.invalid");
-        user.setNickname("ex-player-" + uuid);
-        user.setAvatar("anonymous");
+        var uuid = UUID.randomUUID();
+        user.setEmail(DELETED_EMAIL_PREFIX + uuid + DELETED_EMAIL_SUFFIX);
+        user.setNickname(EX_PLAYER_PREFIX + uuid);
+        user.setAvatar(ANONYMOUS_AVATAR);
         user.setProviderId(null);
         user.setLanguage(null);
         user.setLastNicknameUpdate(null);

--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -8,6 +8,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import com.tictactore.dto.UpdateProfileRequest;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +37,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserCreator userCreator;
+    private final UserOperation userOperation;
     private final ApplicationProperties properties;
     private final Clock clock;
     private final SecureRandom random = new SecureRandom();
@@ -164,83 +168,22 @@ public class UserService {
         }
     }
 
-    @Transactional
+    @Retryable(
+            retryFor = {ObjectOptimisticLockingFailureException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
     public User updateProfile(UUID userId, UpdateProfileRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
-
-        if (request.getNickname() != null && !request.getNickname().trim().isEmpty()) {
-            String sanitized = sanitizeNickname(request.getNickname());
-            if (sanitized.isEmpty()) {
-                throw new com.tictactore.exception.ValidationException("Nickname cannot be empty");
-            }
-            if (!sanitized.equals(user.getNickname())) {
-                if (user.getLastNicknameUpdate() != null) {
-                    Instant nextAllowedUpdate = user.getLastNicknameUpdate().plus(30, ChronoUnit.DAYS);
-                    if (Instant.now(clock).isBefore(nextAllowedUpdate)) {
-                        throw new com.tictactore.exception.ValidationException("Nickname can only be changed once every 30 days");
-                    }
-                }
-                if (userRepository.existsByNickname(sanitized)) {
-                    throw new com.tictactore.exception.ValidationException("Nickname already taken");
-                }
-                user.setNickname(sanitized);
-                user.setLastNicknameUpdate(Instant.now(clock));
-            }
-        }
-
-        if (request.getLanguage() != null) {
-            String lang = request.getLanguage().toUpperCase();
-            if (!lang.equals("EN") && !lang.equals("DE")) {
-                throw new com.tictactore.exception.ValidationException("Language must be EN or DE");
-            }
-            user.setLanguage(lang);
-        }
-
-        if (request.getAvatar() != null) {
-            String avatarVal = request.getAvatar().trim();
-            if (!com.tictactore.validation.AvatarValidator.ALLOWED_AVATARS.contains(avatarVal)) {
-                throw new com.tictactore.exception.ValidationException("Invalid avatar selection");
-            }
-            user.setAvatar(avatarVal);
-        }
-
-        if (request.getTutorialCompleted() != null) {
-            user.setTutorialCompleted(request.getTutorialCompleted());
-        }
-
-        try {
-            return userRepository.save(user);
-        } catch (DataIntegrityViolationException e) {
-            throw new com.tictactore.exception.ValidationException("Nickname already taken");
-        }
+        return userOperation.updateProfile(userId, request);
     }
 
-    @Transactional
+    @Retryable(
+            retryFor = {ObjectOptimisticLockingFailureException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
     public void deleteAccount(UUID userId) {
-        if (userId == null) {
-            throw new IllegalArgumentException("User ID cannot be null");
-        }
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
-
-        if (user.getProviderId() == null && "anonymous".equals(user.getAvatar())) {
-            return;
-        }
-
-        UUID uuid = java.util.UUID.randomUUID();
-        user.setEmail("deleted-" + uuid + "@tic-tac-tore.invalid");
-        user.setNickname("ex-player-" + uuid);
-        user.setAvatar("anonymous");
-        user.setProviderId(null);
-        user.setLanguage(null);
-        user.setLastNicknameUpdate(null);
-
-        try {
-            userRepository.flush();
-        } catch (org.springframework.orm.ObjectOptimisticLockingFailureException e) {
-            throw new IllegalStateException("Account was concurrently modified during deletion. Please try again.", e);
-        }
+        userOperation.deleteAccount(userId);
     }
     public UserPreferencesDto getLastRuleSystem() {
         return new UserPreferencesDto("STANDARD");

--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -13,6 +13,7 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import com.tictactore.dto.UpdateProfileRequest;
+import com.tictactore.exception.UserNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -55,9 +56,9 @@ public class UserService {
 
     @Transactional
     public User findOrCreateTestUser(String email, String nickname, Boolean tutorialCompleted) {
-        Optional<User> existingUser = userRepository.findByEmail(email);
+        var existingUser = userRepository.findByEmail(email);
         if (existingUser.isPresent()) {
-            User user = existingUser.get();
+            var user = existingUser.get();
             if (tutorialCompleted != null) {
                 user.setTutorialCompleted(tutorialCompleted);
                 return userRepository.save(user);
@@ -65,7 +66,7 @@ public class UserService {
             return user;
         }
 
-        User newUser = User.builder()
+        var newUser = User.builder()
                 .email(email)
                 .nickname(nickname)
                 .avatar(generateDeterministicAvatar(email))
@@ -78,13 +79,13 @@ public class UserService {
     @Transactional(readOnly = true)
     public User getProfile(UUID userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new com.tictactore.exception.ResourceNotFoundException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
     }
 
     private User createNewUser(String email, String providerId) {
-        int maxRetries = 3;
+        var maxRetries = 3;
         DataIntegrityViolationException lastException = null;
-        for (int i = 0; i < maxRetries; i++) {
+        for (var i = 0; i < maxRetries; i++) {
             try {
                 var newUser = new User();
                 newUser.setEmail(email);
@@ -119,29 +120,29 @@ public class UserService {
     }
 
     private String generateUniqueNickname(String email) {
-        String prefix = email.split("@")[0];
-        String baseNickname = sanitizeNickname(prefix);
+        var prefix = email.split("@")[0];
+        var baseNickname = sanitizeNickname(prefix);
         if (baseNickname.isEmpty()) {
             baseNickname = "user";
         }
-        String nickname = baseNickname;
+        var nickname = baseNickname;
 
-        int attempts = 0;
+        var attempts = 0;
         while (userRepository.existsByNickname(nickname) && attempts < MAX_NICKNAME_ATTEMPTS) {
             nickname = baseNickname + String.format("%04d", random.nextInt(10000));
             attempts++;
         }
 
         if (attempts >= MAX_NICKNAME_ATTEMPTS) {
-            List<String> candidates = new ArrayList<>();
-            for (int i = 0; i < MAX_NICKNAME_ATTEMPTS; i++) {
-                candidates.add(baseNickname + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8));
+            var candidates = new ArrayList<String>();
+            for (var i = 0; i < MAX_NICKNAME_ATTEMPTS; i++) {
+                candidates.add(baseNickname + UUID.randomUUID().toString().replace("-", "").substring(0, 8));
             }
 
-            List<String> existing = userRepository.findExistingNicknames(candidates);
+            var existing = userRepository.findExistingNicknames(candidates);
 
             String selectedFallback = null;
-            for (String candidate : candidates) {
+            for (var candidate : candidates) {
                 if (!existing.contains(candidate)) {
                     selectedFallback = candidate;
                     break;
@@ -159,9 +160,9 @@ public class UserService {
 
     private String generateDeterministicAvatar(String email) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            String input = email.trim().toLowerCase() + properties.getAvatar().getSalt();
-            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            var digest = MessageDigest.getInstance("SHA-256");
+            var input = email.trim().toLowerCase() + properties.getAvatar().getSalt();
+            var hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
             return properties.getAvatar().getApiUrl() + HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 algorithm not found", e);
@@ -174,7 +175,7 @@ public class UserService {
             backoff = @Backoff(delay = 100)
     )
     public User updateProfile(UUID userId, UpdateProfileRequest request) {
-        return userOperation.updateProfile(userId, request);
+        return userOperation.updateProfile(userId, request.getNickname(), request.getLanguage(), request.getAvatar(), request.getTutorialCompleted());
     }
 
     @Retryable(

--- a/src/test/java/com/tictactore/service/UserOperationTest.java
+++ b/src/test/java/com/tictactore/service/UserOperationTest.java
@@ -1,6 +1,7 @@
 package com.tictactore.service;
 
-import com.tictactore.dto.UpdateProfileRequest;
+import com.tictactore.exception.UserNotFoundException;
+import com.tictactore.exception.ValidationException;
 import com.tictactore.model.User;
 import com.tictactore.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +15,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,18 +40,18 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should update nickname when cooldown passed")
     void updateProfile_shouldUpdateNickname_whenCooldownPassed() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("oldNickname");
-        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(31, java.time.temporal.ChronoUnit.DAYS));
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
+        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(31, ChronoUnit.DAYS));
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("newNickname")).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(clock.instant()).thenReturn(Instant.parse("2026-05-25T12:00:00Z"));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, "newNickname", null, null, null);
 
         assertThat(updatedUser.getNickname()).isEqualTo("newNickname");
         assertThat(updatedUser.getLastNicknameUpdate()).isEqualTo(Instant.parse("2026-05-25T12:00:00Z"));
@@ -59,34 +60,34 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should throw exception when cooldown not passed")
     void updateProfile_shouldThrowException_whenCooldownNotPassed() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("oldNickname");
-        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(15, java.time.temporal.ChronoUnit.DAYS));
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
+        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(15, ChronoUnit.DAYS));
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(clock.instant()).thenReturn(Instant.parse("2026-05-25T12:00:00Z"));
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, "newNickname", null, null, null))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Nickname can only be changed once every 30 days");
     }
 
     @Test
     @DisplayName("Update Profile - should sanitize nickname")
     void updateProfile_shouldSanitizeNickname() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("oldNickname");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("new_Nick-123!").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("newNick123")).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(clock.instant()).thenReturn(Instant.parse("2026-05-25T12:00:00Z"));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, "new_Nick-123!", null, null, null);
 
         assertThat(updatedUser.getNickname()).isEqualTo("newNick123");
     }
@@ -94,59 +95,59 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should throw exception when nickname not unique")
     void updateProfile_shouldThrowException_whenNicknameNotUnique() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("oldNickname");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("takenNickname").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("takenNickname")).thenReturn(true);
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, "takenNickname", null, null, null))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Nickname already taken");
     }
 
     @Test
     @DisplayName("Update Profile - should throw exception on empty sanitized nickname")
     void updateProfile_shouldThrowException_onEmptySanitizedNickname() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("oldNickname");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("!@#").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, "!@#", null, null, null))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Nickname cannot be empty");
     }
 
     @Test
     @DisplayName("Update Profile - should throw exception on invalid language")
     void updateProfile_shouldThrowException_onInvalidLanguage() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().language("FR").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, null, "FR", null, null))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Language must be EN or DE");
     }
 
     @Test
     @DisplayName("Update Profile - should update language")
     void updateProfile_shouldUpdateLanguage() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().language("DE").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, null, "DE", null, null);
 
         assertThat(updatedUser.getLanguage()).isEqualTo("DE");
     }
@@ -154,27 +155,27 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should catch DataIntegrityViolationException and throw ValidationException")
     void updateProfile_shouldCatchDataIntegrityViolationException() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(true).build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, null, null, null, true))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Nickname already taken");
     }
 
     @Test
-    @DisplayName("Update Profile - should throw ResourceNotFoundException when user not found")
-    void updateProfile_shouldThrowResourceNotFoundException() {
-        UUID userId = UUID.randomUUID();
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNick").build();
+    @DisplayName("Update Profile - should throw UserNotFoundException when user not found")
+    void updateProfile_shouldThrowUserNotFoundException() {
+        var userId = UUID.randomUUID();
+
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, "newNick", null, null, null))
+                .isInstanceOf(UserNotFoundException.class)
                 .hasMessage("User not found");
     }
 
@@ -182,16 +183,16 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should update avatar when avatar whitelisted")
     void updateProfile_shouldUpdateAvatar_whenAvatarWhitelisted() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("nickname");
         user.setAvatar("old-avatar");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("ball-classic").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, null, null, "ball-classic", null);
 
         assertThat(updatedUser.getAvatar()).isEqualTo("ball-classic");
     }
@@ -199,48 +200,48 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should throw exception when avatar is anonymous")
     void updateProfile_shouldThrowException_whenAvatarIsAnonymous() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("nickname");
         user.setAvatar("old-avatar");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("anonymous").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, null, null, "anonymous", null))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Invalid avatar selection");
     }
 
     @Test
     @DisplayName("Update Profile - should throw exception when avatar is empty")
     void updateProfile_shouldThrowException_whenAvatarIsEmpty() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setNickname("nickname");
         user.setAvatar("old-avatar");
         user.setEmail("test@example.com");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("").build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, null, null, "", null))
+                .isInstanceOf(ValidationException.class)
                 .hasMessage("Invalid avatar selection");
     }
 
     @Test
     @DisplayName("Update Profile - should update tutorialCompleted when provided")
     void updateProfile_shouldUpdateTutorialCompleted_whenProvided() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setTutorialCompleted(false);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(true).build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, null, null, null, true);
 
         assertThat(updatedUser.isTutorialCompleted()).isTrue();
     }
@@ -248,15 +249,15 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should update tutorialCompleted to false when explicitly provided")
     void updateProfile_shouldUpdateTutorialCompletedToFalse_whenProvided() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setTutorialCompleted(true);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(false).build();
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, null, null, null, false);
 
         assertThat(updatedUser.isTutorialCompleted()).isFalse();
     }
@@ -264,15 +265,15 @@ class UserOperationTest {
     @Test
     @DisplayName("Update Profile - should not modify tutorialCompleted when omitted from request")
     void updateProfile_shouldNotModifyTutorialCompleted_whenOmitted() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
+        var userId = UUID.randomUUID();
+        var user = new User();
         user.setId(userId);
         user.setTutorialCompleted(true);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().build(); // tutorialCompleted is null
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User updatedUser = userOperation.updateProfile(userId, request);
+        var updatedUser = userOperation.updateProfile(userId, null, null, null, null);
 
         assertThat(updatedUser.isTutorialCompleted()).isTrue();
     }
@@ -280,8 +281,8 @@ class UserOperationTest {
     @Test
     @DisplayName("Delete Account - should anonymize user data")
     void deleteAccount_shouldAnonymizeUserData() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
+        var userId = UUID.randomUUID();
+        var user = User.builder()
                 .id(userId)
                 .email("test@example.com")
                 .nickname("player1")
@@ -308,19 +309,19 @@ class UserOperationTest {
     @Test
     @DisplayName("Delete Account - should throw exception when user not found")
     void deleteAccount_shouldThrowException_whenUserNotFound() {
-        UUID userId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userOperation.deleteAccount(userId))
-                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+                .isInstanceOf(UserNotFoundException.class)
                 .hasMessageContaining("User not found");
     }
 
     @Test
     @DisplayName("Delete Account - should return early if already anonymous")
     void deleteAccount_shouldReturnEarlyIfAlreadyAnonymous() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
+        var userId = UUID.randomUUID();
+        var user = User.builder()
                 .id(userId)
                 .email("deleted-abc@tic-tac-tore.invalid")
                 .nickname("ex-player-abc")
@@ -345,8 +346,8 @@ class UserOperationTest {
     @Test
     @DisplayName("Delete Account - should keep user ID intact and never call delete on repository to preserve references")
     void deleteAccount_shouldKeepUserIdIntactAndNeverCallDelete() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
+        var userId = UUID.randomUUID();
+        var user = User.builder()
                 .id(userId)
                 .email("test@example.com")
                 .nickname("player1")
@@ -365,8 +366,8 @@ class UserOperationTest {
     @Test
     @DisplayName("Delete Account - should propagate ObjectOptimisticLockingFailureException")
     void deleteAccount_shouldPropagateObjectOptimisticLockingFailureException() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
+        var userId = UUID.randomUUID();
+        var user = User.builder()
                 .id(userId)
                 .email("test@example.com")
                 .nickname("player1")

--- a/src/test/java/com/tictactore/service/UserOperationTest.java
+++ b/src/test/java/com/tictactore/service/UserOperationTest.java
@@ -1,0 +1,383 @@
+package com.tictactore.service;
+
+import com.tictactore.dto.UpdateProfileRequest;
+import com.tictactore.model.User;
+import com.tictactore.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserOperation Tests")
+class UserOperationTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private UserOperation userOperation;
+
+    @Test
+    @DisplayName("Update Profile - should update nickname when cooldown passed")
+    void updateProfile_shouldUpdateNickname_whenCooldownPassed() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("oldNickname");
+        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(31, java.time.temporal.ChronoUnit.DAYS));
+        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("newNickname")).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(clock.instant()).thenReturn(Instant.parse("2026-05-25T12:00:00Z"));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.getNickname()).isEqualTo("newNickname");
+        assertThat(updatedUser.getLastNicknameUpdate()).isEqualTo(Instant.parse("2026-05-25T12:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw exception when cooldown not passed")
+    void updateProfile_shouldThrowException_whenCooldownNotPassed() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("oldNickname");
+        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(15, java.time.temporal.ChronoUnit.DAYS));
+        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(clock.instant()).thenReturn(Instant.parse("2026-05-25T12:00:00Z"));
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Nickname can only be changed once every 30 days");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should sanitize nickname")
+    void updateProfile_shouldSanitizeNickname() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("oldNickname");
+        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("new_Nick-123!").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("newNick123")).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(clock.instant()).thenReturn(Instant.parse("2026-05-25T12:00:00Z"));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.getNickname()).isEqualTo("newNick123");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw exception when nickname not unique")
+    void updateProfile_shouldThrowException_whenNicknameNotUnique() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("oldNickname");
+        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("takenNickname").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("takenNickname")).thenReturn(true);
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Nickname already taken");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw exception on empty sanitized nickname")
+    void updateProfile_shouldThrowException_onEmptySanitizedNickname() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("oldNickname");
+        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("!@#").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Nickname cannot be empty");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw exception on invalid language")
+    void updateProfile_shouldThrowException_onInvalidLanguage() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        UpdateProfileRequest request = UpdateProfileRequest.builder().language("FR").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Language must be EN or DE");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should update language")
+    void updateProfile_shouldUpdateLanguage() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        UpdateProfileRequest request = UpdateProfileRequest.builder().language("DE").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.getLanguage()).isEqualTo("DE");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should catch DataIntegrityViolationException and throw ValidationException")
+    void updateProfile_shouldCatchDataIntegrityViolationException() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(true).build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Nickname already taken");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw ResourceNotFoundException when user not found")
+    void updateProfile_shouldThrowResourceNotFoundException() {
+        UUID userId = UUID.randomUUID();
+        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNick").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+                .hasMessage("User not found");
+    }
+
+
+    @Test
+    @DisplayName("Update Profile - should update avatar when avatar whitelisted")
+    void updateProfile_shouldUpdateAvatar_whenAvatarWhitelisted() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("nickname");
+        user.setAvatar("old-avatar");
+        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("ball-classic").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.getAvatar()).isEqualTo("ball-classic");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw exception when avatar is anonymous")
+    void updateProfile_shouldThrowException_whenAvatarIsAnonymous() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("nickname");
+        user.setAvatar("old-avatar");
+        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("anonymous").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Invalid avatar selection");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should throw exception when avatar is empty")
+    void updateProfile_shouldThrowException_whenAvatarIsEmpty() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setNickname("nickname");
+        user.setAvatar("old-avatar");
+        user.setEmail("test@example.com");
+        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("").build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userOperation.updateProfile(userId, request))
+                .isInstanceOf(com.tictactore.exception.ValidationException.class)
+                .hasMessage("Invalid avatar selection");
+    }
+
+    @Test
+    @DisplayName("Update Profile - should update tutorialCompleted when provided")
+    void updateProfile_shouldUpdateTutorialCompleted_whenProvided() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setTutorialCompleted(false);
+        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(true).build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.isTutorialCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Update Profile - should update tutorialCompleted to false when explicitly provided")
+    void updateProfile_shouldUpdateTutorialCompletedToFalse_whenProvided() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setTutorialCompleted(true);
+        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(false).build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.isTutorialCompleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Update Profile - should not modify tutorialCompleted when omitted from request")
+    void updateProfile_shouldNotModifyTutorialCompleted_whenOmitted() {
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setTutorialCompleted(true);
+        UpdateProfileRequest request = UpdateProfileRequest.builder().build(); // tutorialCompleted is null
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User updatedUser = userOperation.updateProfile(userId, request);
+
+        assertThat(updatedUser.isTutorialCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Delete Account - should anonymize user data")
+    void deleteAccount_shouldAnonymizeUserData() {
+        UUID userId = UUID.randomUUID();
+        User user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .nickname("player1")
+                .avatar("https://avatar.url")
+                .providerId("google-123")
+                .language("RU")
+                .lastNicknameUpdate(Instant.now())
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        userOperation.deleteAccount(userId);
+
+        assertThat(user.getId()).isEqualTo(userId);
+        assertThat(user.getEmail()).startsWith("deleted-").endsWith("@tic-tac-tore.invalid");
+        assertThat(user.getNickname()).startsWith("ex-player-");
+        assertThat(user.getAvatar()).isEqualTo("anonymous");
+        assertThat(user.getProviderId()).isNull();
+        assertThat(user.getLanguage()).isNull();
+        assertThat(user.getLastNicknameUpdate()).isNull();
+
+        verify(userRepository).flush();
+    }
+
+    @Test
+    @DisplayName("Delete Account - should throw exception when user not found")
+    void deleteAccount_shouldThrowException_whenUserNotFound() {
+        UUID userId = UUID.randomUUID();
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userOperation.deleteAccount(userId))
+                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    @DisplayName("Delete Account - should return early if already anonymous")
+    void deleteAccount_shouldReturnEarlyIfAlreadyAnonymous() {
+        UUID userId = UUID.randomUUID();
+        User user = User.builder()
+                .id(userId)
+                .email("deleted-abc@tic-tac-tore.invalid")
+                .nickname("ex-player-abc")
+                .avatar("anonymous")
+                .providerId(null)
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        userOperation.deleteAccount(userId);
+
+        verify(userRepository, never()).flush();
+    }
+
+    @Test
+    @DisplayName("Delete Account - should throw IllegalArgumentException when userId is null")
+    void deleteAccount_shouldThrowIllegalArgumentException() {
+        assertThatThrownBy(() -> userOperation.deleteAccount(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("User ID cannot be null");
+    }
+
+    @Test
+    @DisplayName("Delete Account - should keep user ID intact and never call delete on repository to preserve references")
+    void deleteAccount_shouldKeepUserIdIntactAndNeverCallDelete() {
+        UUID userId = UUID.randomUUID();
+        User user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .nickname("player1")
+                .avatar("https://avatar.url")
+                .providerId("google-123")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        userOperation.deleteAccount(userId);
+
+        assertThat(user.getId()).isEqualTo(userId);
+        verify(userRepository, never()).delete(any());
+        verify(userRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("Delete Account - should propagate ObjectOptimisticLockingFailureException")
+    void deleteAccount_shouldPropagateObjectOptimisticLockingFailureException() {
+        UUID userId = UUID.randomUUID();
+        User user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .nickname("player1")
+                .avatar("https://avatar.url")
+                .providerId("google-123")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        doThrow(new ObjectOptimisticLockingFailureException(User.class, userId))
+                .when(userRepository).flush();
+
+        assertThatThrownBy(() -> userOperation.deleteAccount(userId))
+                .isInstanceOf(ObjectOptimisticLockingFailureException.class);
+    }
+}

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.BadCredentialsException;
 
 import com.tictactore.dto.UpdateProfileRequest;
+import com.tictactore.exception.UserNotFoundException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -144,7 +145,7 @@ class UserServiceTest {
         when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
+        var user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
 
         assertThat(user.getNickname()).isEqualTo("new");
     }
@@ -157,7 +158,7 @@ class UserServiceTest {
         when(userRepository.existsByNickname(argThat(s -> s != null && !s.equals("new")))).thenReturn(false);
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
+        var user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
 
         assertThat(user.getNickname()).startsWith("new");
         assertThat(user.getNickname()).hasSize(7);
@@ -169,9 +170,9 @@ class UserServiceTest {
         when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
+        var user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
 
-        String expectedHash = "19d7f5455ecc3199ffa0f29a6755a288fceb6b88ec694e053c5aa24b4317771c";
+        var expectedHash = "19d7f5455ecc3199ffa0f29a6755a288fceb6b88ec694e053c5aa24b4317771c";
         assertThat(user.getAvatar()).isEqualTo("https://api.dicebear.com/7.x/identicon/svg?seed=" + expectedHash);
     }
 
@@ -186,7 +187,7 @@ class UserServiceTest {
                 .build();
         when(userRepository.findByEmail(EMAIL_EXISTING)).thenReturn(Optional.of(existing));
 
-        User user = userService.findOrCreate(EMAIL_EXISTING, SUB_EXISTING);
+        var user = userService.findOrCreate(EMAIL_EXISTING, SUB_EXISTING);
 
         assertThat(user.getNickname()).isEqualTo("custom_nick");
         assertThat(user.getAvatar()).isEqualTo("custom_avatar");
@@ -217,7 +218,7 @@ class UserServiceTest {
         when(userRepository.findById(id)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.getProfile(id))
-                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
+                .isInstanceOf(UserNotFoundException.class)
                 .hasMessageContaining("User not found");
     }
 
@@ -227,7 +228,7 @@ class UserServiceTest {
         when(userRepository.findByEmail("test.user+123@example.com")).thenReturn(Optional.empty());
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        User user = userService.findOrCreate("test.user+123@example.com", SUB_NEW);
+        var user = userService.findOrCreate("test.user+123@example.com", SUB_NEW);
 
         assertThat(user.getNickname()).isEqualTo("testuser123");
     }
@@ -239,7 +240,7 @@ class UserServiceTest {
         when(userRepository.existsByNickname(anyString())).thenReturn(true, true, true, true, true, true, true, true, true, true, true, false);
         when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        User user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
+        var user = userService.findOrCreate(EMAIL_NEW, SUB_NEW);
 
         assertThat(user.getNickname()).startsWith("new");
         assertThat(user.getNickname().length()).isEqualTo(11);
@@ -248,22 +249,27 @@ class UserServiceTest {
     @Test
     @DisplayName("Update Profile - should delegate to UserOperation")
     void updateProfile_shouldDelegateToUserOperation() {
-        UUID userId = UUID.randomUUID();
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
-        User expectedUser = new User();
+        var userId = UUID.randomUUID();
+        var request = UpdateProfileRequest.builder()
+                .nickname("newNickname")
+                .language("DE")
+                .avatar("ball-classic")
+                .tutorialCompleted(true)
+                .build();
+        var expectedUser = new User();
         expectedUser.setNickname("newNickname");
-        when(userOperation.updateProfile(userId, request)).thenReturn(expectedUser);
+        when(userOperation.updateProfile(userId, "newNickname", "DE", "ball-classic", true)).thenReturn(expectedUser);
 
-        User actualUser = userService.updateProfile(userId, request);
+        var actualUser = userService.updateProfile(userId, request);
 
         assertThat(actualUser).isSameAs(expectedUser);
-        verify(userOperation).updateProfile(userId, request);
+        verify(userOperation).updateProfile(userId, "newNickname", "DE", "ball-classic", true);
     }
 
     @Test
     @DisplayName("Delete Account - should delegate to UserOperation")
     void deleteAccount_shouldDelegateToUserOperation() {
-        UUID userId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
 
         userService.deleteAccount(userId);
 

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -47,6 +47,9 @@ class UserServiceTest {
     private UserCreator userCreator;
 
     @Mock
+    private UserOperation userOperation;
+
+    @Mock
     private ApplicationProperties properties;
 
     @Mock
@@ -243,247 +246,28 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("Update Profile - should update nickname when cooldown passed")
-    void updateProfile_shouldUpdateNickname_whenCooldownPassed() {
+    @DisplayName("Update Profile - should delegate to UserOperation")
+    void updateProfile_shouldDelegateToUserOperation() {
         UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("oldNickname");
-        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(31, java.time.temporal.ChronoUnit.DAYS));
         UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.existsByNickname("newNickname")).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        User expectedUser = new User();
+        expectedUser.setNickname("newNickname");
+        when(userOperation.updateProfile(userId, request)).thenReturn(expectedUser);
 
-        User updatedUser = userService.updateProfile(userId, request);
+        User actualUser = userService.updateProfile(userId, request);
 
-        assertThat(updatedUser.getNickname()).isEqualTo("newNickname");
-        assertThat(updatedUser.getLastNicknameUpdate()).isEqualTo(Instant.parse("2026-05-25T12:00:00Z"));
+        assertThat(actualUser).isSameAs(expectedUser);
+        verify(userOperation).updateProfile(userId, request);
     }
 
     @Test
-    @DisplayName("Update Profile - should throw exception when cooldown not passed")
-    void updateProfile_shouldThrowException_whenCooldownNotPassed() {
+    @DisplayName("Delete Account - should delegate to UserOperation")
+    void deleteAccount_shouldDelegateToUserOperation() {
         UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("oldNickname");
-        user.setLastNicknameUpdate(Instant.parse("2026-05-25T12:00:00Z").minus(15, java.time.temporal.ChronoUnit.DAYS));
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("newNickname").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        assertThatThrownBy(() -> userService.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
-                .hasMessage("Nickname can only be changed once every 30 days");
-    }
-
-    @Test
-    @DisplayName("Update Profile - should sanitize nickname")
-    void updateProfile_shouldSanitizeNickname() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("oldNickname");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("new_Nick-123!").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.existsByNickname("newNick123")).thenReturn(false);
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        User updatedUser = userService.updateProfile(userId, request);
-
-        assertThat(updatedUser.getNickname()).isEqualTo("newNick123");
-    }
-
-    @Test
-    @DisplayName("Update Profile - should throw exception when nickname not unique")
-    void updateProfile_shouldThrowException_whenNicknameNotUnique() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("oldNickname");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().nickname("takenNickname").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.existsByNickname("takenNickname")).thenReturn(true);
-
-        assertThatThrownBy(() -> userService.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
-                .hasMessage("Nickname already taken");
-    }
-
-    @Test
-    @DisplayName("Delete Account - should anonymize user data")
-    void deleteAccount_shouldAnonymizeUserData() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
-                .id(userId)
-                .email("test@example.com")
-                .nickname("player1")
-                .avatar("https://avatar.url")
-                .providerId("google-123")
-                .language("RU")
-                .lastNicknameUpdate(Instant.now())
-                .build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
         userService.deleteAccount(userId);
 
-        assertThat(user.getId()).isEqualTo(userId);
-        assertThat(user.getEmail()).startsWith("deleted-").endsWith("@tic-tac-tore.invalid");
-        assertThat(user.getNickname()).startsWith("ex-player-");
-        assertThat(user.getAvatar()).isEqualTo("anonymous");
-        assertThat(user.getProviderId()).isNull();
-        assertThat(user.getLanguage()).isNull();
-        assertThat(user.getLastNicknameUpdate()).isNull();
-        
-        verify(userRepository).flush();
-    }
-
-    @Test
-    @DisplayName("Delete Account - should throw exception when user not found")
-    void deleteAccount_shouldThrowException_whenUserNotFound() {
-        UUID userId = UUID.randomUUID();
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> userService.deleteAccount(userId))
-                .isInstanceOf(com.tictactore.exception.ResourceNotFoundException.class)
-                .hasMessageContaining("User not found");
-    }
-
-    @Test
-    @DisplayName("Delete Account - should keep user ID intact and never call delete on repository to preserve references")
-    void deleteAccount_shouldKeepUserIdIntactAndNeverCallDelete() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
-                .id(userId)
-                .email("test@example.com")
-                .nickname("player1")
-                .avatar("https://avatar.url")
-                .providerId("google-123")
-                .build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        userService.deleteAccount(userId);
-
-        assertThat(user.getId()).isEqualTo(userId);
-        verify(userRepository, never()).delete(any());
-        verify(userRepository, never()).deleteById(any());
-    }
-
-    @Test
-    @DisplayName("Delete Account - should throw IllegalStateException when optimistic locking failure occurs")
-    void deleteAccount_shouldThrowIllegalStateException_onOptimisticLockingFailure() {
-        UUID userId = UUID.randomUUID();
-        User user = User.builder()
-                .id(userId)
-                .email("test@example.com")
-                .nickname("player1")
-                .avatar("https://avatar.url")
-                .providerId("google-123")
-                .build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        doThrow(new org.springframework.orm.ObjectOptimisticLockingFailureException(User.class, userId))
-                .when(userRepository).flush();
-
-        assertThatThrownBy(() -> userService.deleteAccount(userId))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Account was concurrently modified during deletion. Please try again.");
-    }
-
-    @Test
-    @DisplayName("Update Profile - should update avatar when avatar whitelisted")
-    void updateProfile_shouldUpdateAvatar_whenAvatarWhitelisted() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("nickname");
-        user.setAvatar("old-avatar");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("ball-classic").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        User updatedUser = userService.updateProfile(userId, request);
-
-        assertThat(updatedUser.getAvatar()).isEqualTo("ball-classic");
-    }
-
-    @Test
-    @DisplayName("Update Profile - should throw exception when avatar is anonymous")
-    void updateProfile_shouldThrowException_whenAvatarIsAnonymous() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("nickname");
-        user.setAvatar("old-avatar");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("anonymous").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        assertThatThrownBy(() -> userService.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
-                .hasMessage("Invalid avatar selection");
-    }
-
-    @Test
-    @DisplayName("Update Profile - should throw exception when avatar is empty")
-    void updateProfile_shouldThrowException_whenAvatarIsEmpty() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setNickname("nickname");
-        user.setAvatar("old-avatar");
-        user.setEmail("test@example.com");
-        UpdateProfileRequest request = UpdateProfileRequest.builder().avatar("").build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        assertThatThrownBy(() -> userService.updateProfile(userId, request))
-                .isInstanceOf(com.tictactore.exception.ValidationException.class)
-                .hasMessage("Invalid avatar selection");
-    }
-
-    @Test
-    @DisplayName("Update Profile - should update tutorialCompleted when provided")
-    void updateProfile_shouldUpdateTutorialCompleted_whenProvided() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setTutorialCompleted(false);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(true).build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        User updatedUser = userService.updateProfile(userId, request);
-
-        assertThat(updatedUser.isTutorialCompleted()).isTrue();
-    }
-    @Test
-    @DisplayName("Update Profile - should update tutorialCompleted to false when explicitly provided")
-    void updateProfile_shouldUpdateTutorialCompletedToFalse_whenProvided() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setTutorialCompleted(true);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().tutorialCompleted(false).build();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        User updatedUser = userService.updateProfile(userId, request);
-
-        assertThat(updatedUser.isTutorialCompleted()).isFalse();
-    }
-
-    @Test
-    @DisplayName("Update Profile - should not modify tutorialCompleted when omitted from request")
-    void updateProfile_shouldNotModifyTutorialCompleted_whenOmitted() {
-        UUID userId = UUID.randomUUID();
-        User user = new User();
-        user.setId(userId);
-        user.setTutorialCompleted(true);
-        UpdateProfileRequest request = UpdateProfileRequest.builder().build(); // tutorialCompleted is null
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        User updatedUser = userService.updateProfile(userId, request);
-
-        assertThat(updatedUser.isTutorialCompleted()).isTrue();
+        verify(userOperation).deleteAccount(userId);
     }
 }
 


### PR DESCRIPTION
🎯 What
Fixed unhandled `OptimisticLockingFailureException` during concurrent user profile updates and account deletions.

💡 Why
When two requests concurrently attempt to update the same user profile or delete the account, JPA's optimistic locking throws an exception that wasn't being handled, leading to 500 internal server errors.

✅ Verification
- Run `./mvnw test` to ensure all tests in `UserServiceTest` and `UserOperationTest` pass.
- Code conforms to AAA testing patterns and strict `@Transactional` / `@Retryable` isolation rules.

✨ Result
User operations now automatically retry up to 3 times upon optimistic locking failures.

---
*PR created automatically by Jules for task [5591964617331500942](https://jules.google.com/task/5591964617331500942) started by @phalbohr*