### PR TITLE
🐛 [Bug fix] Prevent Nickname Length Overflow on user creation

### DIFF
--- a/src/main/java/com/tictactore/service/UserService.java
+++ b/src/main/java/com/tictactore/service/UserService.java
@@ -120,6 +120,7 @@ public class UserService {
         if (baseNickname.isEmpty()) {
             baseNickname = "user";
         }
+        baseNickname = baseNickname.substring(0, Math.min(baseNickname.length(), 40));
         String nickname = baseNickname;
 
         int attempts = 0;

--- a/src/test/java/com/tictactore/service/UserServiceTest.java
+++ b/src/test/java/com/tictactore/service/UserServiceTest.java
@@ -68,6 +68,19 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("Find or Create - should truncate long email prefix for nickname")
+    void findOrCreate_shouldTruncateLongEmailPrefix() {
+        String longEmail = "thisisaverylongemailprefixthatgoeswaybeyondsixtyfourcharacters@example.com";
+        when(userRepository.findByEmail(longEmail)).thenReturn(Optional.empty());
+        when(userCreator.createUser(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        User user = userService.findOrCreate(longEmail, SUB_NEW);
+
+        assertThat(user.getNickname().length()).isLessThanOrEqualTo(48);
+        assertThat(user.getNickname()).startsWith("thisisaverylongemailprefixthatgoeswaybey");
+    }
+
+    @Test
     @DisplayName("Create User - should save and return new user when email not found")
     void findOrCreate_createsNewUser_whenEmailNotFound() {
         when(userRepository.findByEmail(EMAIL_NEW)).thenReturn(Optional.empty());


### PR DESCRIPTION
🎯 What
Truncated the `baseNickname` to a maximum of 40 characters in `UserService.generateUniqueNickname` before appending UUID or random digits. Also added a unit test to verify truncation for long email prefixes.

💡 Why
To prevent a potential `Nickname Length Overflow` where a 64-character email prefix combined with an 8-character UUID could exceed typical database or validation limits (e.g., 73 characters).

✅ Verification
Ran the backend test suite (`./mvnw test`) successfully. The new test `findOrCreate_shouldTruncateLongEmailPrefix` ensures the nickname stays within expected bounds.

✨ Result
Nicknames generated from long emails are safely truncated, preventing database insertion errors or validation failures due to excessive string length.

---
*PR created automatically by Jules for task [15457102464082489366](https://jules.google.com/task/15457102464082489366) started by @phalbohr*