### PR TITLE
🧹 resolve DW-1 follow-up review recommendation in ledger

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -5,7 +5,8 @@ origin: review-budget-followup
 source_spec: `spec-2-3-score-entry-and-automatic-completion.md`
 severity: low
 reason: The follow-up-review damping cap (limits.max_followup_reviews = 1) was spent with the story finalized (status: done, verify green) while the review pass still recommended an independent follow-up. The work was committed by bmad-loop run 20260717-193102-8fc5; this entry preserves the lingering recommendation for a deliberate later review.
-status: open
+status: done 2026-07-23
+resolution: already resolved: The follow-up code review was already performed, resulting in other DW issues being logged (e.g., DW-32, DW-33).
 decision: 2026-07-19 Run Review — Run a bmad-code-review session on the score entry code to catch any remaining issues.
 
 ### DW-2: Critical security vulnerabilities, including "JWT Leaked in URL", "XSS Exposure via LocalStorage", and "Account Takeover via Email Collision", are explicitly deferred to a later time. Merging code with known critical security flaws compromises the application and user data. These vulnerabilities must be fixed in the current PR.


### PR DESCRIPTION
🎯 What: Closed the DW-1 ticket in the deferred work ledger.
💡 Why: The DW-1 task was a meta-ticket representing a follow-up review. The user confirmed this review has already taken place (resulting in other logged DW issues like DW-32 and DW-33), so this ticket is resolved without code changes.
✅ Verification: Confirmed with the user via prompt and verified that the ledger reflects the closed status correctly.
✨ Result: `deferred-work.md` now shows DW-1 as `done` with an explanatory resolution note.

---
*PR created automatically by Jules for task [16946073510508772919](https://jules.google.com/task/16946073510508772919) started by @phalbohr*