### PR TITLE
🐛 [Add E2E test support controller for anonymization verification]

### DIFF
--- a/src/main/java/com/tictactore/config/SecurityConfig.java
+++ b/src/main/java/com/tictactore/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
         java.util.List<String> publicEndpoints = new java.util.ArrayList<>(java.util.Arrays.asList(PUBLIC_ENDPOINTS));
         if (env.acceptsProfiles(org.springframework.core.env.Profiles.of("test", "e2e"))) {
             publicEndpoints.add("/api/auth/test-login");
+            publicEndpoints.add("/api/e2e/**");
         }
 
         http

--- a/src/main/java/com/tictactore/controller/E2ETestSupportController.java
+++ b/src/main/java/com/tictactore/controller/E2ETestSupportController.java
@@ -1,7 +1,6 @@
 package com.tictactore.controller;
 
-import com.tictactore.model.User;
-import com.tictactore.repository.UserRepository;
+import com.tictactore.service.E2ETestSupportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,19 +15,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class E2ETestSupportController {
 
-    private final UserRepository userRepository;
+    private final E2ETestSupportService e2eTestSupportService;
 
     @GetMapping("/users")
     public List<com.tictactore.dto.E2EUserDto> getAllUsers() {
-        return userRepository.findAll().stream()
-                .map(user -> com.tictactore.dto.E2EUserDto.builder()
-                        .id(user.getId())
-                        .email(user.getEmail())
-                        .nickname(user.getNickname())
-                        .providerId(user.getProviderId())
-                        .avatar(user.getAvatar())
-                        .language(user.getLanguage())
-                        .build())
-                .toList();
+        return e2eTestSupportService.getAllUsers();
     }
 }

--- a/src/main/java/com/tictactore/controller/E2ETestSupportController.java
+++ b/src/main/java/com/tictactore/controller/E2ETestSupportController.java
@@ -19,7 +19,16 @@ public class E2ETestSupportController {
     private final UserRepository userRepository;
 
     @GetMapping("/users")
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public List<com.tictactore.dto.E2EUserDto> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(user -> com.tictactore.dto.E2EUserDto.builder()
+                        .id(user.getId())
+                        .email(user.getEmail())
+                        .nickname(user.getNickname())
+                        .providerId(user.getProviderId())
+                        .avatar(user.getAvatar())
+                        .language(user.getLanguage())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/tictactore/controller/E2ETestSupportController.java
+++ b/src/main/java/com/tictactore/controller/E2ETestSupportController.java
@@ -1,0 +1,25 @@
+package com.tictactore.controller;
+
+import com.tictactore.model.User;
+import com.tictactore.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Profile({"e2e", "test"})
+@RestController
+@RequestMapping("/api/e2e")
+@RequiredArgsConstructor
+public class E2ETestSupportController {
+
+    private final UserRepository userRepository;
+
+    @GetMapping("/users")
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+}

--- a/src/main/java/com/tictactore/dto/E2EUserDto.java
+++ b/src/main/java/com/tictactore/dto/E2EUserDto.java
@@ -1,0 +1,16 @@
+package com.tictactore.dto;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class E2EUserDto {
+    private UUID id;
+    private String email;
+    private String nickname;
+    private String providerId;
+    private String avatar;
+    private String language;
+}

--- a/src/main/java/com/tictactore/service/E2ETestSupportService.java
+++ b/src/main/java/com/tictactore/service/E2ETestSupportService.java
@@ -1,0 +1,32 @@
+package com.tictactore.service;
+
+import com.tictactore.dto.E2EUserDto;
+import com.tictactore.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Profile({"e2e", "test"})
+@Service
+@RequiredArgsConstructor
+public class E2ETestSupportService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<E2EUserDto> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(user -> E2EUserDto.builder()
+                        .id(user.getId())
+                        .email(user.getEmail())
+                        .nickname(user.getNickname())
+                        .providerId(user.getProviderId())
+                        .avatar(user.getAvatar())
+                        .language(user.getLanguage())
+                        .build())
+                .toList();
+    }
+}


### PR DESCRIPTION
🎯 What
Added a dedicated `E2ETestSupportController` annotated with `@Profile({"e2e", "test"})` containing a `GET /api/e2e/users` endpoint to fetch all users.

💡 Why
To resolve DW-8. TC-P0-004 needs to assert that an anonymized record has no PII via an API call after account deletion. However, account deletion revokes authentication (401), so a client-side E2E test cannot assert state without elevated endpoints. The critical instruction states that test endpoints must be strictly protected via Spring `@Profile` and not pollute production controllers.

✅ Verification
Ran all backend tests (`./mvnw clean test`) and verified that 60 tests passed without regressions. Confirmed the controller is excluded from production builds via the `@Profile` annotation. Code review passed.

✨ Result
E2E tests can now fetch the full list of users via `/api/e2e/users` to verify that the PII of a deleted user has been properly scrubbed, without introducing any backdoors into production builds.

---
*PR created automatically by Jules for task [4478341112777739066](https://jules.google.com/task/4478341112777739066) started by @phalbohr*