### PR TITLE
🐛 Fix ScoreEntry hardcoded array indices for team names

### DIFF
--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -20,19 +20,13 @@ const getPlayerName = (id?: string) => {
 }
 
 const team1Name = computed(() => {
-  if (store.matchType === MatchType.ONE_VS_ONE) {
-    return getPlayerName(store.selectedPlayers[0])
-  } else {
-    return `${getPlayerName(store.selectedPlayers[0])} & ${getPlayerName(store.selectedPlayers[1])}`
-  }
+  const half = Math.ceil(store.selectedPlayers.length / 2)
+  return store.selectedPlayers.slice(0, half).map(id => getPlayerName(id)).join(' & ') || 'Team 1'
 })
 
 const team2Name = computed(() => {
-  if (store.matchType === MatchType.ONE_VS_ONE) {
-    return getPlayerName(store.selectedPlayers[1])
-  } else {
-    return `${getPlayerName(store.selectedPlayers[2])} & ${getPlayerName(store.selectedPlayers[3])}`
-  }
+  const half = Math.ceil(store.selectedPlayers.length / 2)
+  return store.selectedPlayers.slice(half).map(id => getPlayerName(id)).join(' & ') || 'Team 2'
 })
 
 const team1Wins = computed(() => {

--- a/frontend/src/features/match/components/__tests__/ScoreEntry.spec.ts
+++ b/frontend/src/features/match/components/__tests__/ScoreEntry.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ScoreEntry from '../ScoreEntry.vue'
+import { useMatchDraftStore, MatchType } from '../../stores/matchDraftStore'
+
+describe('ScoreEntry.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders correctly for 1v1', () => {
+    const store = useMatchDraftStore()
+    store.frequentOpponents = [
+      { id: 'p1', nickname: 'Alice', avatar: '' },
+      { id: 'p2', nickname: 'Bob', avatar: '' }
+    ]
+    store.selectedPlayers = ['p1', 'p2']
+    store.matchType = MatchType.ONE_VS_ONE
+
+    const wrapper = mount(ScoreEntry)
+    const headings = wrapper.findAll('h3')
+
+    expect(headings.length).toBe(2)
+    expect(headings[0].text()).toBe('Alice')
+    expect(headings[1].text()).toBe('Bob')
+  })
+
+  it('renders correctly for 2v2', () => {
+    const store = useMatchDraftStore()
+    store.frequentOpponents = [
+      { id: 'p1', nickname: 'Alice', avatar: '' },
+      { id: 'p2', nickname: 'Bob', avatar: '' },
+      { id: 'p3', nickname: 'Charlie', avatar: '' },
+      { id: 'p4', nickname: 'Dave', avatar: '' }
+    ]
+
+    store.selectedPlayers = ['p1', 'p2', 'p3', 'p4']
+
+    store.matchType = MatchType.TWO_VS_TWO
+
+    const wrapper = mount(ScoreEntry)
+    const headings = wrapper.findAll('h3')
+
+    expect(headings[0].text()).toBe('Alice & Bob')
+    expect(headings[1].text()).toBe('Charlie & Dave')
+  })
+
+  it('renders correctly for 3v3 (6 players)', () => {
+    const store = useMatchDraftStore()
+    store.frequentOpponents = [
+      { id: 'p1', nickname: 'P1', avatar: '' },
+      { id: 'p2', nickname: 'P2', avatar: '' },
+      { id: 'p3', nickname: 'P3', avatar: '' },
+      { id: 'p4', nickname: 'P4', avatar: '' },
+      { id: 'p5', nickname: 'P5', avatar: '' },
+      { id: 'p6', nickname: 'P6', avatar: '' }
+    ]
+    store.selectedPlayers = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6']
+
+    const wrapper = mount(ScoreEntry)
+    const headings = wrapper.findAll('h3')
+
+    expect(headings[0].text()).toBe('P1 & P2 & P3')
+    expect(headings[1].text()).toBe('P4 & P5 & P6')
+  })
+})


### PR DESCRIPTION
🎯 What
Updated `ScoreEntry.vue` to compute `team1Name` and `team2Name` dynamically by splitting the `selectedPlayers` array in half using `Array.slice()`.
Added `ScoreEntry.spec.ts` unit tests to verify the output for 1v1, 2v2, and 3v3 scenarios.

💡 Why
The component previously hardcoded indices (e.g. `store.selectedPlayers[2]`), meaning matches extended beyond 2v2 (like 3v3) would fail to render the additional players and could result in undefined values being accessed.

✅ Verification
Ran `npm run test:unit --prefix frontend` locally. Specifically confirmed the new tests in `ScoreEntry.spec.ts` pass, successfully verifying team names resolve correctly in 1v1, 2v2, and 3v3 scenarios.

✨ Result
The application now supports dynamic match sizes gracefully when generating team names during score entry.

---
*PR created automatically by Jules for task [1210856442082751239](https://jules.google.com/task/1210856442082751239) started by @phalbohr*