### PR TITLE
✨ [Add undo mechanism for game transitions]

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -189,8 +189,8 @@ resolution: already resolved: matchDraftStore.ts:144 and :147 reject increments 
 origin: migrated from legacy ledger ("Deferred from: code review of 5-1-real-time-scoring-interface-landscape.md (2026-07-05)"), 2026-07-19
 location: n/a
 reason: Provide an undo mechanism for game transitions in multi-game matches before final submission.
-status: done 2026-07-24
-resolution: implemented undoLastGame in matchDraftStore and added Undo button to ScoreEntry.vue
+status: done 2026-07-25
+resolution: fixed in PR #139 (with canUndoLastGame guard against active score data loss)
 
 ### DW-29: Allow score decrementing to revert a game win state if tapped immediately.
 origin: migrated from legacy ledger ("Deferred from: code review of 5-1-real-time-scoring-interface-landscape.md (2026-07-05)"), 2026-07-19

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -189,7 +189,8 @@ resolution: already resolved: matchDraftStore.ts:144 and :147 reject increments 
 origin: migrated from legacy ledger ("Deferred from: code review of 5-1-real-time-scoring-interface-landscape.md (2026-07-05)"), 2026-07-19
 location: n/a
 reason: Provide an undo mechanism for game transitions in multi-game matches before final submission.
-status: open
+status: done 2026-07-24
+resolution: implemented undoLastGame in matchDraftStore and added Undo button to ScoreEntry.vue
 
 ### DW-29: Allow score decrementing to revert a game win state if tapped immediately.
 origin: migrated from legacy ledger ("Deferred from: code review of 5-1-real-time-scoring-interface-landscape.md (2026-07-05)"), 2026-07-19

--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -119,7 +119,7 @@ watch(() => store.matchState, (newVal) => {
       </BaseButton>
 
       <BaseButton
-        v-if="store.games.length > 0"
+        v-if="store.canUndoLastGame"
         variant="secondary"
         @click="store.undoLastGame()"
         class="w-full"

--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -109,12 +109,23 @@ watch(() => store.matchState, (newVal) => {
       </div>
     </div>
     
-    <BaseButton 
-      :disabled="!store.isGameComplete"
-      @click="store.completeCurrentGame()"
-      class="w-full mt-6"
-    >
-      {{ store.isMatchComplete ? 'Complete Match' : 'Next Game' }}
-    </BaseButton>
+    <div class="flex flex-col gap-2 mt-6 w-full">
+      <BaseButton
+        :disabled="!store.isGameComplete"
+        @click="store.completeCurrentGame()"
+        class="w-full"
+      >
+        {{ store.isMatchComplete ? 'Complete Match' : 'Next Game' }}
+      </BaseButton>
+
+      <BaseButton
+        v-if="store.games.length > 0"
+        variant="secondary"
+        @click="store.undoLastGame()"
+        class="w-full"
+      >
+        Undo Last Game
+      </BaseButton>
+    </div>
   </div>
 </template>

--- a/frontend/src/features/match/stores/matchDraftStore.spec.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.spec.ts
@@ -139,5 +139,38 @@ describe('matchDraftStore', () => {
       expect(store.games.length).toBe(2)
       expect(store.matchState).toBe('ready_for_submission')
     })
+
+    it('undos last game correctly', () => {
+      const store = useMatchDraftStore()
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 3, winsNeeded: 2 }
+
+      store.incrementScore(1, 5)
+      store.completeCurrentGame()
+      expect(store.games.length).toBe(1)
+      expect(store.matchState).toBe('draft')
+
+      store.undoLastGame()
+      expect(store.games.length).toBe(0)
+      expect(store.currentGame.team1Score).toBe(5)
+      expect(store.matchState).toBe('score_entry')
+    })
+
+    it('undos last game from ready_for_submission state', () => {
+      const store = useMatchDraftStore()
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 2, winsNeeded: 3 }
+
+      store.incrementScore(1, 5)
+      store.completeCurrentGame()
+
+      store.incrementScore(1, 5)
+      store.completeCurrentGame()
+      expect(store.games.length).toBe(2)
+      expect(store.matchState).toBe('ready_for_submission')
+
+      store.undoLastGame()
+      expect(store.games.length).toBe(1)
+      expect(store.currentGame.team1Score).toBe(5)
+      expect(store.matchState).toBe('score_entry')
+    })
   })
 })

--- a/frontend/src/features/match/stores/matchDraftStore.spec.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.spec.ts
@@ -172,5 +172,20 @@ describe('matchDraftStore', () => {
       expect(store.currentGame.team1Score).toBe(5)
       expect(store.matchState).toBe('score_entry')
     })
+
+    it('prevents undo when points are already scored in current game', () => {
+      const store = useMatchDraftStore()
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 3, winsNeeded: 2 }
+
+      store.incrementScore(1, 5)
+      store.completeCurrentGame()
+      expect(store.games.length).toBe(1)
+
+      store.incrementScore(2, 2)
+      expect(store.canUndoLastGame).toBe(false)
+      store.undoLastGame()
+      expect(store.games.length).toBe(1)
+      expect(store.currentGame.team2Score).toBe(2)
+    })
   })
 })

--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -177,6 +177,15 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     matchState.value = 'score_entry'
   }
 
+  function undoLastGame() {
+    if (games.value.length === 0) return
+    const lastGame = games.value.pop()
+    if (lastGame) {
+      currentGame.value = { ...lastGame }
+      matchState.value = 'score_entry'
+    }
+  }
+
   function reset() {
     matchType.value = MatchType.ONE_VS_ONE
     selectedPlayers.value = []
@@ -207,6 +216,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     removePlayer,
     incrementScore,
     decrementScore,
+    undoLastGame,
     beginScoreEntry,
     reset
   }

--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -140,6 +140,12 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     return t1w >= winsNeeded || t2w >= winsNeeded || (games.value.length + 1) >= gameLimit
   })
 
+  const canUndoLastGame = computed(() => {
+    if (games.value.length === 0) return false
+    if (matchState.value === 'ready_for_submission') return true
+    return currentGame.value.team1Score === 0 && currentGame.value.team2Score === 0
+  })
+
   function incrementScore(team: 1 | 2, amount: number) {
     if (matchState.value === 'ready_for_submission') return
     
@@ -178,7 +184,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
   }
 
   function undoLastGame() {
-    if (games.value.length === 0) return
+    if (!canUndoLastGame.value) return
     const lastGame = games.value.pop()
     if (lastGame) {
       currentGame.value = { ...lastGame }
@@ -204,6 +210,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     fetchedPlayers,
     isGameComplete,
     isMatchComplete,
+    canUndoLastGame,
     completeCurrentGame,
     ruleConfig,
     games,


### PR DESCRIPTION
🎯 What: Added `undoLastGame` action to `matchDraftStore` to restore the last game's state from the completed games array back to `currentGame`, effectively undoing a "Next Game" transition. Added an "Undo Last Game" button to `ScoreEntry.vue` that displays only when a game has already been completed.
💡 Why: Provides users a way to correct an accidental click on "Next Game" before they finalize the entire match submission, addressing Deferred Work item DW-28.
✅ Verification: Added unit tests validating undo functionality from normal flow as well as recovering from a `ready_for_submission` state back to `score_entry`. Tests pass successfully.
✨ Result: Resolved DW-28.

---
*PR created automatically by Jules for task [7973289128155705811](https://jules.google.com/task/7973289128155705811) started by @phalbohr*