### PR TITLE
✨ Add confirmation modal on score entry cancellation

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -202,7 +202,8 @@ resolution: already resolved: ScoreEntry.vue:112 manual 'Next Game' button requi
 origin: migrated from legacy ledger ("Deferred from: code review of 5-1-real-time-scoring-interface-landscape.md (2026-07-05)"), 2026-07-19
 location: n/a
 reason: Add confirmation dialog when clicking Cancel in the score entry view to prevent accidental resets.
-status: open
+status: done 2026-07-25
+resolution: fixed in PR #140
 
 ### DW-31: Add a back button in the score entry view to return to player selection.
 origin: migrated from legacy ledger ("Deferred from: code review of 5-1-real-time-scoring-interface-landscape.md (2026-07-05)"), 2026-07-19

--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, watch, ref } from 'vue'
 import { useMatchDraftStore, MatchType } from '../stores/matchDraftStore'
 import ScoreStepper from './ScoreStepper.vue'
 import BaseButton from '@/core/components/BaseButton.vue'
@@ -9,6 +9,8 @@ const emit = defineEmits<{
   (e: 'complete'): void
   (e: 'cancel'): void
 }>()
+
+const showCancelModal = ref(false)
 
 const getPlayerName = (id?: string) => {
   if (!id) return 'Unknown'
@@ -65,9 +67,9 @@ watch(() => store.matchState, (newVal) => {
 
 <template>
   <div class="w-full flex flex-col bg-surface-container-low rounded-2xl p-4">
-    <!-- Header with past match context -->
+
     <div class="relative flex items-center justify-center mb-6">
-      <BaseButton variant="secondary" @click="emit('cancel')" class="!h-10 px-4 absolute left-0">Cancel</BaseButton>
+      <BaseButton variant="secondary" @click="showCancelModal = true" class="!h-10 px-4 absolute left-0">Cancel</BaseButton>
       <div class="text-on-surface-variant text-base font-bold flex flex-col items-center">
         <span>Match Score</span>
         <span class="text-xl text-on-surface">{{ team1Wins }} - {{ team2Wins }}</span>
@@ -86,7 +88,7 @@ watch(() => store.matchState, (newVal) => {
     </div>
     
     <div class="flex justify-between gap-4">
-      <!-- Team 1 -->
+
       <div class="flex-1 flex flex-col items-center">
         <h3 class="text-on-surface font-bold text-center mb-4 h-12 w-full block overflow-hidden text-ellipsis line-clamp-2 break-words">{{ team1Name }}</h3>
         <ScoreStepper 
@@ -97,7 +99,6 @@ watch(() => store.matchState, (newVal) => {
         />
       </div>
       
-      <!-- Team 2 -->
       <div class="flex-1 flex flex-col items-center">
         <h3 class="text-on-surface font-bold text-center mb-4 h-12 w-full block overflow-hidden text-ellipsis line-clamp-2 break-words">{{ team2Name }}</h3>
         <ScoreStepper 
@@ -116,5 +117,56 @@ watch(() => store.matchState, (newVal) => {
     >
       {{ store.isMatchComplete ? 'Complete Match' : 'Next Game' }}
     </BaseButton>
+
+    <Transition name="fade">
+      <div
+        v-if="showCancelModal"
+        class="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/75 backdrop-blur-md"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="w-full max-w-sm bg-surface-container-low rounded-2xl p-6 space-y-6 shadow-2xl">
+          <div class="text-center space-y-2">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-red-950/30 text-red-400 mb-2">
+              <span class="material-symbols-outlined text-2xl">warning</span>
+            </div>
+            <h2 class="font-headline text-lg font-bold text-on-surface">
+              Cancel Match
+            </h2>
+            <p class="text-xs text-on-surface-variant leading-relaxed">
+              Are you sure you want to cancel this match? All recorded scores will be lost.
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <button
+              @click="emit('cancel')"
+              class="w-full py-3 rounded-xl bg-red-600 hover:bg-red-700 text-white font-headline font-extrabold uppercase tracking-wider text-xs transition-colors flex items-center justify-center gap-2"
+            >
+              Confirm Cancel
+            </button>
+
+            <button
+              @click="showCancelModal = false"
+              class="w-full py-3 rounded-xl bg-surface-container-highest hover:bg-surface-container-highest/80 text-on-surface font-headline font-bold text-xs transition-colors"
+            >
+              Keep Playing
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
   </div>
 </template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -118,7 +118,7 @@ watch(() => store.matchState, (newVal) => {
       {{ store.isMatchComplete ? 'Complete Match' : 'Next Game' }}
     </BaseButton>
 
-    <Transition name="fade">
+    <Transition name="ch-fade">
       <div
         v-if="showCancelModal"
         class="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/75 backdrop-blur-md"
@@ -139,19 +139,20 @@ watch(() => store.matchState, (newVal) => {
           </div>
 
           <div class="flex flex-col gap-2">
-            <button
-              @click="emit('cancel')"
-              class="w-full py-3 rounded-xl bg-red-600 hover:bg-red-700 text-white font-headline font-extrabold uppercase tracking-wider text-xs transition-colors flex items-center justify-center gap-2"
+            <BaseButton
+              @click="showCancelModal = false; emit('cancel')"
+              class="w-full !bg-red-600 hover:!bg-red-700 !text-white font-headline font-extrabold uppercase tracking-wider text-xs !h-12"
             >
               Confirm Cancel
-            </button>
+            </BaseButton>
 
-            <button
+            <BaseButton
+              variant="secondary"
               @click="showCancelModal = false"
-              class="w-full py-3 rounded-xl bg-surface-container-highest hover:bg-surface-container-highest/80 text-on-surface font-headline font-bold text-xs transition-colors"
+              class="w-full font-headline font-bold text-xs !h-12"
             >
               Keep Playing
-            </button>
+            </BaseButton>
           </div>
         </div>
       </div>
@@ -160,13 +161,13 @@ watch(() => store.matchState, (newVal) => {
 </template>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
+.ch-fade-enter-active,
+.ch-fade-leave-active {
   transition: opacity 0.2s ease;
 }
 
-.fade-enter-from,
-.fade-leave-to {
+.ch-fade-enter-from,
+.ch-fade-leave-to {
   opacity: 0;
 }
 </style>


### PR DESCRIPTION
🎯 What: 
Added a confirmation modal when the user clicks the "Cancel" button in the `ScoreEntry.vue` component. The modal uses a standard fade transition and prompts the user to confirm they want to cancel before emitting the `cancel` event.

💡 Why:
To prevent accidental match score resets (issue DW-30), improving the user experience by adding an intentional confirmation step.

✅ Verification:
Ran frontend unit tests via Vitest which passed successfully. Wrote a custom Playwright verification script to visually inspect the rendered cancel modal layout.

✨ Result:
Users are now prompted with a confirmation dialog when attempting to cancel a match from the score entry screen.

---
*PR created automatically by Jules for task [3711267838373551685](https://jules.google.com/task/3711267838373551685) started by @phalbohr*