### PR TITLE
✨ Add back button to score entry view

### DIFF
--- a/frontend/src/features/match/components/NewMatchFlow.vue
+++ b/frontend/src/features/match/components/NewMatchFlow.vue
@@ -50,6 +50,10 @@ function handleCancel() {
   emit('cancel')
 }
 
+function handleBack() {
+  store.returnToDraft()
+}
+
 function handleMatchReady() {
   emit('complete')
 }
@@ -79,6 +83,7 @@ function handleMatchReady() {
     v-else-if="store.matchState === 'score_entry' || store.matchState === 'ready_for_submission'" 
     @complete="handleMatchReady" 
     @cancel="handleCancel" 
+    @back="handleBack"
   />
   
   <div v-else class="w-full flex flex-col items-center bg-surface-container-low rounded-2xl p-4 gap-6">

--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -8,6 +8,7 @@ const store = useMatchDraftStore()
 const emit = defineEmits<{
   (e: 'complete'): void
   (e: 'cancel'): void
+  (e: 'back'): void
 }>()
 
 const getPlayerName = (id?: string) => {
@@ -67,11 +68,12 @@ watch(() => store.matchState, (newVal) => {
   <div class="w-full flex flex-col bg-surface-container-low rounded-2xl p-4">
     <!-- Header with past match context -->
     <div class="relative flex items-center justify-center mb-6">
-      <BaseButton variant="secondary" @click="emit('cancel')" class="!h-10 px-4 absolute left-0">Cancel</BaseButton>
+      <BaseButton variant="secondary" @click="emit('back')" class="!h-10 px-4 absolute left-0">Back</BaseButton>
       <div class="text-on-surface-variant text-base font-bold flex flex-col items-center">
         <span>Match Score</span>
         <span class="text-xl text-on-surface">{{ team1Wins }} - {{ team2Wins }}</span>
       </div>
+      <BaseButton variant="secondary" @click="emit('cancel')" class="!h-10 px-4 absolute right-0">Cancel</BaseButton>
     </div>
     
     <div class="flex flex-col items-center mb-4 gap-1">

--- a/frontend/src/features/match/components/__tests__/ScoreEntry.spec.ts
+++ b/frontend/src/features/match/components/__tests__/ScoreEntry.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import ScoreEntry from '../ScoreEntry.vue'
+import { createTestingPinia } from '@pinia/testing'
+import { useMatchDraftStore } from '../../stores/matchDraftStore'
+import { setActivePinia, createPinia } from 'pinia'
+
+describe('ScoreEntry.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits back event when back button is clicked', async () => {
+    const wrapper = mount(ScoreEntry, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              matchDraft: {
+                matchState: 'score_entry',
+                games: [],
+                currentGame: { team1Score: 0, team2Score: 0 },
+                ruleConfig: { gameLimit: 3 },
+                frequentOpponents: [],
+                fetchedPlayers: {},
+                selectedPlayers: ['p1', 'p2']
+              }
+            }
+          })
+        ]
+      }
+    })
+
+    const backButton = wrapper.findAll('button').find(w => w.text().includes('Back'))
+    expect(backButton).toBeDefined()
+    await backButton!.trigger('click')
+
+    expect(wrapper.emitted()).toHaveProperty('back')
+  })
+})

--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -177,6 +177,12 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     matchState.value = 'score_entry'
   }
 
+  function returnToDraft() {
+    games.value = []
+    currentGame.value = { team1Score: 0, team2Score: 0 }
+    matchState.value = 'draft'
+  }
+
   function reset() {
     matchType.value = MatchType.ONE_VS_ONE
     selectedPlayers.value = []
@@ -208,6 +214,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     incrementScore,
     decrementScore,
     beginScoreEntry,
+    returnToDraft,
     reset
   }
 })


### PR DESCRIPTION
🎯 What
Added a 'Back' button to the score entry view of the new match flow, allowing users to return to the player selection step (`draft` state) while resetting the score and games arrays.

💡 Why
To resolve DW-31, providing users an explicit way to return to player selection if they proceeded to score entry prematurely, without having to cancel the entire match creation process.

✅ Verification
- Unit test coverage for new `ScoreEntry.vue` interactions verifying it emits the event properly.
- Fully passed all `frontend` unit tests.
- Locally verified frontend visual screenshot testing via Playwright to ensure the button appeared properly. E2E execution was skipped due to local dev server constraints, requiring local manual verification by a reviewer.

✨ Result
Users can now back out of match score entry gracefully and return to player selection.

---
*PR created automatically by Jules for task [2828663364037876240](https://jules.google.com/task/2828663364037876240) started by @phalbohr*