### PR TITLE
🐛 [fix] Fix hardcoded win logic without win-by-two

### DIFF
--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -92,6 +92,7 @@ watch(() => store.matchState, (newVal) => {
         <ScoreStepper 
           :score="store.currentGame.team1Score"
           :score-limit="store.ruleConfig?.scoreLimit || 10"
+          :win-by-two="store.ruleConfig?.winByTwo || false"
           @increment="onTeam1Increment"
           @decrement="onTeam1Decrement"
         />
@@ -103,6 +104,7 @@ watch(() => store.matchState, (newVal) => {
         <ScoreStepper 
           :score="store.currentGame.team2Score"
           :score-limit="store.ruleConfig?.scoreLimit || 10"
+          :win-by-two="store.ruleConfig?.winByTwo || false"
           @increment="onTeam2Increment"
           @decrement="onTeam2Decrement"
         />

--- a/frontend/src/features/match/components/ScoreStepper.vue
+++ b/frontend/src/features/match/components/ScoreStepper.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   score: number
   scoreLimit: number
+  winByTwo?: boolean
 }>()
 const emit = defineEmits<{
   (e: 'increment', amount: number): void
@@ -13,7 +14,7 @@ const emit = defineEmits<{
   <div class="flex flex-col items-center gap-2">
     <!-- +5 stepper, visually distinct and larger, disabled if scoreLimit < 5 from current -->
     <button v-if="scoreLimit >= 5"
-            :disabled="(scoreLimit - score) < 5" 
+            :disabled="!winByTwo && (scoreLimit - score) < 5"
             @click="emit('increment', 5)"
             aria-label="Add 5"
             class="disabled:opacity-50 disabled:cursor-not-allowed bg-surface-container-highest text-on-surface font-bold text-2xl w-24 h-16 rounded-xl flex items-center justify-center cursor-pointer hover:bg-surface-container-highest/80 transition-colors">
@@ -22,7 +23,7 @@ const emit = defineEmits<{
     
     <!-- +1 stepper -->
     <button @click="emit('increment', 1)"
-            :disabled="score >= scoreLimit"
+            :disabled="!winByTwo && score >= scoreLimit"
             aria-label="Add 1"
             class="disabled:opacity-50 disabled:cursor-not-allowed bg-surface-container-highest text-on-surface font-bold text-xl w-20 h-12 rounded-xl flex items-center justify-center cursor-pointer hover:bg-surface-container-highest/80 transition-colors mt-2">
       +1

--- a/frontend/src/features/match/stores/matchDraftStore.spec.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.spec.ts
@@ -49,11 +49,11 @@ describe('matchDraftStore', () => {
     it('handles successful loadRuleConfig', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ scoreLimit: 5, gameLimit: 3, winsNeeded: 2 })
+        json: async () => ({ scoreLimit: 5, gameLimit: 3, winsNeeded: 2, winByTwo: true })
       })
       const store = useMatchDraftStore()
       await store.loadRuleConfig()
-      expect(store.ruleConfig).toEqual({ scoreLimit: 5, gameLimit: 3, winsNeeded: 2 })
+      expect(store.ruleConfig).toEqual({ scoreLimit: 5, gameLimit: 3, winsNeeded: 2, winByTwo: true })
     })
 
     it('handles API error in loadRuleConfig by falling back to standard', async () => {
@@ -62,12 +62,12 @@ describe('matchDraftStore', () => {
       })
       const store = useMatchDraftStore()
       await store.loadRuleConfig()
-      expect(store.ruleConfig).toEqual({ scoreLimit: 10, gameLimit: 3, winsNeeded: 2 })
+      expect(store.ruleConfig).toEqual({ scoreLimit: 10, gameLimit: 3, winsNeeded: 2, winByTwo: false })
     })
 
     it('increments score but caps at scoreLimit, requires manual complete', async () => {
       const store = useMatchDraftStore()
-      store.ruleConfig = { scoreLimit: 5, gameLimit: 1, winsNeeded: 1 }
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 1, winsNeeded: 1, winByTwo: false }
       store.incrementScore(1, 1)
       expect(store.currentGame.team1Score).toBe(1)
       
@@ -93,9 +93,36 @@ describe('matchDraftStore', () => {
       expect(store.currentGame.team2Score).toBe(0)
     })
 
+    it('increments score past limit when winByTwo is true', async () => {
+      const store = useMatchDraftStore()
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 1, winsNeeded: 1, winByTwo: true }
+
+      store.incrementScore(1, 4)
+      store.incrementScore(2, 4)
+      expect(store.currentGame.team1Score).toBe(4)
+      expect(store.currentGame.team2Score).toBe(4)
+      expect(store.isGameComplete).toBe(false)
+
+      store.incrementScore(1, 1) // 5 - 4
+      expect(store.currentGame.team1Score).toBe(5)
+      expect(store.isGameComplete).toBe(false) // Needs 2 point lead
+
+      store.incrementScore(2, 1) // 5 - 5
+      expect(store.currentGame.team2Score).toBe(5)
+      expect(store.isGameComplete).toBe(false)
+
+      store.incrementScore(1, 1) // 6 - 5
+      expect(store.currentGame.team1Score).toBe(6)
+      expect(store.isGameComplete).toBe(false)
+
+      store.incrementScore(1, 1) // 7 - 5
+      expect(store.currentGame.team1Score).toBe(7)
+      expect(store.isGameComplete).toBe(true) // Has 2 point lead
+    })
+
     it('manually completes a game and starts next when scoreLimit is reached', () => {
       const store = useMatchDraftStore()
-      store.ruleConfig = { scoreLimit: 5, gameLimit: 3, winsNeeded: 2 }
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 3, winsNeeded: 2, winByTwo: false }
       store.incrementScore(1, 5)
       expect(store.isGameComplete).toBe(true)
       
@@ -108,7 +135,7 @@ describe('matchDraftStore', () => {
 
     it('manually completes match when winsNeeded is reached', () => {
       const store = useMatchDraftStore()
-      store.ruleConfig = { scoreLimit: 5, gameLimit: 3, winsNeeded: 2 }
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 3, winsNeeded: 2, winByTwo: false }
       
       // Game 1
       store.incrementScore(1, 5)
@@ -125,7 +152,7 @@ describe('matchDraftStore', () => {
     
     it('manually completes match when gameLimit is reached', () => {
       const store = useMatchDraftStore()
-      store.ruleConfig = { scoreLimit: 5, gameLimit: 2, winsNeeded: 3 }
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 2, winsNeeded: 3, winByTwo: false }
       
       // Game 1
       store.incrementScore(2, 5)

--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -23,6 +23,7 @@ export interface RuleConfig {
   scoreLimit: number
   gameLimit: number
   winsNeeded: number
+  winByTwo: boolean
 }
 
 export const useMatchDraftStore = defineStore('matchDraft', () => {
@@ -72,7 +73,8 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
         ruleConfig.value = { 
           scoreLimit: Number(data.scoreLimit), 
           gameLimit: Number(data.gameLimit), 
-          winsNeeded: Number(data.winsNeeded) 
+          winsNeeded: Number(data.winsNeeded),
+          winByTwo: Boolean(data.winByTwo)
         }
       } else {
         throw new Error('API failed')
@@ -81,7 +83,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
       const e = error as Error;
       if (e.name === 'AbortError') throw e;
       console.warn('Failed to load rule config, falling back to Best of 3 rules', e)
-      ruleConfig.value = { scoreLimit: 10, gameLimit: 3, winsNeeded: 2 }
+      ruleConfig.value = { scoreLimit: 10, gameLimit: 3, winsNeeded: 2, winByTwo: false }
     }
   }
 
@@ -122,7 +124,14 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
 
   const isGameComplete = computed(() => {
     const limit = ruleConfig.value?.scoreLimit ?? 10
-    return currentGame.value.team1Score >= limit || currentGame.value.team2Score >= limit
+    const reachedLimit = currentGame.value.team1Score >= limit || currentGame.value.team2Score >= limit
+    if (!reachedLimit) return false
+
+    if (ruleConfig.value?.winByTwo) {
+      return Math.abs(currentGame.value.team1Score - currentGame.value.team2Score) >= 2
+    }
+
+    return true
   })
 
   const isMatchComplete = computed(() => {
@@ -144,10 +153,16 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     if (matchState.value === 'ready_for_submission') return
     
     const limit = ruleConfig.value?.scoreLimit ?? 10
+    const winByTwo = ruleConfig.value?.winByTwo ?? false
+
     if (team === 1) {
-      currentGame.value.team1Score = Math.min(currentGame.value.team1Score + amount, limit)
+      currentGame.value.team1Score = winByTwo
+        ? currentGame.value.team1Score + amount
+        : Math.min(currentGame.value.team1Score + amount, limit)
     } else {
-      currentGame.value.team2Score = Math.min(currentGame.value.team2Score + amount, limit)
+      currentGame.value.team2Score = winByTwo
+        ? currentGame.value.team2Score + amount
+        : Math.min(currentGame.value.team2Score + amount, limit)
     }
   }
 


### PR DESCRIPTION
🎯 What
- Implemented frontend support for the `winByTwo` match configuration.
- `RuleConfig` in `matchDraftStore` now pulls the `winByTwo` setting from the API response.
- Game completion logic (`isGameComplete`) requires a 2-point lead when the rule is active, preventing early completion if scores are tied at the limit.
- Score entry (`incrementScore` and UI buttons in `ScoreStepper`) can now proceed past the score limit when `winByTwo` is active.

💡 Why
- Fixes DW-32: The match scoring logic previously used a hard absolute score limit, breaking support for games configured with "Win by 2" where the match continues indefinitely beyond the normal limit until a 2-point lead is established.

✅ Verification
- Updated mock API responses in `matchDraftStore.spec.ts` to supply the new field.
- Added a new store unit test asserting that scores are allowed to go above the game limit and `isGameComplete` strictly returns false until a 2-point lead occurs.
- Executed frontend tests via `vitest`, ensuring no regressions.

✨ Result
- Users can properly log and finalize scores for matches configured with standard "Win by 2" rules without being artificially blocked by hard score limits in the UI.

---
*PR created automatically by Jules for task [12667419791032311670](https://jules.google.com/task/12667419791032311670) started by @phalbohr*