### PR TITLE
🐛 [test fix] Fix timeout in match-submission-undo.spec.ts by updating increment button locator

### DIFF
--- a/frontend/e2e/tests/e2e/match-submission-undo.spec.ts
+++ b/frontend/e2e/tests/e2e/match-submission-undo.spec.ts
@@ -83,7 +83,7 @@ test.describe('Story 2.4: Match Submission with Undo Window', () => {
     await startBtn.click();
 
     // 4. Increment score to win limit (5) and complete match
-    const incrementBtn = page.locator('.score-stepper button').first();
+    const incrementBtn = page.getByRole('button', { name: 'Add 1' }).first();
     for (let i = 0; i < 5; i++) {
       await incrementBtn.click();
     }
@@ -112,7 +112,7 @@ test.describe('Story 2.4: Match Submission with Undo Window', () => {
     await page.getByRole('button', { name: /Start Match/i }).click();
 
     // 2. Increment score to win (5) and complete match
-    const incrementBtn = page.locator('.score-stepper button').first();
+    const incrementBtn = page.getByRole('button', { name: 'Add 1' }).first();
     for (let i = 0; i < 5; i++) {
       await incrementBtn.click();
     }
@@ -149,7 +149,7 @@ test.describe('Story 2.4: Match Submission with Undo Window', () => {
     await page.getByRole('button', { name: 'Bob' }).click();
     await page.getByRole('button', { name: /Start Match/i }).click();
 
-    const incrementBtn = page.locator('.score-stepper button').first();
+    const incrementBtn = page.getByRole('button', { name: 'Add 1' }).first();
     for (let i = 0; i < 5; i++) {
       await incrementBtn.click();
     }


### PR DESCRIPTION
🎯 What
Updated the Playwright e2e test `match-submission-undo.spec.ts` to use a more resilient accessibility locator (`getByRole`) for the increment score button instead of a brittle CSS selector (`.score-stepper button`).

💡 Why
The CSS selector was causing timeouts during CI pipeline runs, preventing the tests from successfully clicking the increment button to simulate a match score reaching the target limit.

✅ Verification
Ran the failing E2E test file via Playwright locally and verified all 12 test assertions now pass across Chromium, Firefox, and WebKit without timing out.

✨ Result
Resolved the blocking CI failure for the Match Submission Undo Story (2.4).

---
*PR created automatically by Jules for task [18414910868615058389](https://jules.google.com/task/18414910868615058389) started by @phalbohr*