### PR TITLE
✨ [Story 2.5] Implement position swapping between games for 2v2 matches

### DIFF
--- a/frontend/src/features/match/components/PositionSwapDialog.vue
+++ b/frontend/src/features/match/components/PositionSwapDialog.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import BaseButton from '@/core/components/BaseButton.vue'
+import { useMatchDraftStore } from '../stores/matchDraftStore'
+import { computed } from 'vue'
+
+defineOptions({
+  name: 'PositionSwapDialog'
+})
+
+const store = useMatchDraftStore()
+
+const getPlayerName = (id?: string) => {
+  if (!id) return 'Unknown'
+  const opp = store.frequentOpponents.find((o) => o.id === id)
+  if (opp) return opp.nickname
+  const fetched = store.fetchedPlayers[id]
+  if (fetched) return fetched.nickname
+  return `Player ${id.substring(0, 4)}`
+}
+
+const team1AttackerName = computed(() => getPlayerName(store.currentGame.teamAAttackerId))
+const team1DefenderName = computed(() => getPlayerName(store.currentGame.teamADefenderId))
+
+const team2AttackerName = computed(() => getPlayerName(store.currentGame.teamBAttackerId))
+const team2DefenderName = computed(() => getPlayerName(store.currentGame.teamBDefenderId))
+
+function confirm() {
+  store.confirmPositions()
+}
+
+function swapTeam1() {
+  store.swapPositions(1)
+}
+
+function swapTeam2() {
+  store.swapPositions(2)
+}
+</script>
+
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/75 backdrop-blur-md ch-position-swap" role="dialog" aria-modal="true">
+    <div class="w-full max-w-sm bg-surface-container-low rounded-2xl p-6 space-y-6 shadow-2xl">
+      <div class="text-center space-y-2">
+        <h2 class="font-headline text-xl font-bold text-on-surface">
+          Confirm Positions
+        </h2>
+        <p class="text-xs text-on-surface-variant leading-relaxed">
+          Who is attacking and who is defending?
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <!-- Team 1 -->
+        <div class="flex flex-col bg-surface-container p-4 rounded-xl">
+          <div class="font-bold text-on-surface mb-2 text-center">Team 1</div>
+          <div class="flex justify-between items-center text-sm mb-1">
+            <span class="text-on-surface-variant">Attacker:</span>
+            <span class="font-bold">{{ team1AttackerName }}</span>
+          </div>
+          <div class="flex justify-between items-center text-sm mb-3">
+            <span class="text-on-surface-variant">Defender:</span>
+            <span class="font-bold">{{ team1DefenderName }}</span>
+          </div>
+          <BaseButton variant="secondary" @click="swapTeam1" class="!h-8 text-xs">Swap Team 1</BaseButton>
+        </div>
+
+        <!-- Team 2 -->
+        <div class="flex flex-col bg-surface-container p-4 rounded-xl">
+          <div class="font-bold text-on-surface mb-2 text-center">Team 2</div>
+          <div class="flex justify-between items-center text-sm mb-1">
+            <span class="text-on-surface-variant">Attacker:</span>
+            <span class="font-bold">{{ team2AttackerName }}</span>
+          </div>
+          <div class="flex justify-between items-center text-sm mb-3">
+            <span class="text-on-surface-variant">Defender:</span>
+            <span class="font-bold">{{ team2DefenderName }}</span>
+          </div>
+          <BaseButton variant="secondary" @click="swapTeam2" class="!h-8 text-xs">Swap Team 2</BaseButton>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2 mt-4">
+        <BaseButton
+          @click="confirm"
+          class="w-full font-headline font-bold text-xs !h-12"
+        >
+          Confirm & Play
+        </BaseButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/match/components/ScoreEntry.vue
+++ b/frontend/src/features/match/components/ScoreEntry.vue
@@ -2,6 +2,7 @@
 import { computed, watch, ref } from 'vue'
 import { useMatchDraftStore, type PlayerDto, type GameScore } from '../stores/matchDraftStore'
 import ScoreStepper from './ScoreStepper.vue'
+import PositionSwapDialog from './PositionSwapDialog.vue'
 import BaseButton from '@/core/components/BaseButton.vue'
 
 const store = useMatchDraftStore()
@@ -126,6 +127,10 @@ watch(() => store.matchState, (newVal) => {
         Undo Last Game
       </BaseButton>
     </div>
+
+    <Transition name="ch-fade">
+      <PositionSwapDialog v-if="store.matchState === 'position_swap'" />
+    </Transition>
 
     <Transition name="ch-fade">
       <div

--- a/frontend/src/features/match/stores/matchDraftStore.spec.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.spec.ts
@@ -45,6 +45,54 @@ describe('matchDraftStore', () => {
     expect(store.selectedPlayers).toEqual([])
   })
 
+  describe('Position Swapping', () => {
+    it('sets state to position_swap for 2v2 games on beginScoreEntry', () => {
+      const store = useMatchDraftStore()
+      store.setMatchType(MatchType.TWO_VS_TWO)
+      store.addPlayer('p1')
+      store.addPlayer('p2')
+      store.addPlayer('p3')
+      store.addPlayer('p4')
+
+      store.beginScoreEntry()
+      expect(store.matchState).toBe('position_swap')
+      expect(store.currentGame.teamAAttackerId).toBe('p1')
+      expect(store.currentGame.teamADefenderId).toBe('p2')
+      expect(store.currentGame.teamBAttackerId).toBe('p3')
+      expect(store.currentGame.teamBDefenderId).toBe('p4')
+    })
+
+    it('sets state to score_entry for 1v1 games on beginScoreEntry', () => {
+      const store = useMatchDraftStore()
+      store.setMatchType(MatchType.ONE_VS_ONE)
+      store.addPlayer('p1')
+      store.addPlayer('p2')
+
+      store.beginScoreEntry()
+      expect(store.matchState).toBe('score_entry')
+    })
+
+    it('swaps positions and confirms correctly', () => {
+      const store = useMatchDraftStore()
+      store.setMatchType(MatchType.TWO_VS_TWO)
+      store.addPlayer('p1')
+      store.addPlayer('p2')
+      store.addPlayer('p3')
+      store.addPlayer('p4')
+
+      store.beginScoreEntry()
+      expect(store.currentGame.teamAAttackerId).toBe('p1')
+      expect(store.currentGame.teamADefenderId).toBe('p2')
+
+      store.swapPositions(1)
+      expect(store.currentGame.teamAAttackerId).toBe('p2')
+      expect(store.currentGame.teamADefenderId).toBe('p1')
+
+      store.confirmPositions()
+      expect(store.matchState).toBe('score_entry')
+    })
+  })
+
   describe('Score Entry and Manual Completion', () => {
     it('handles successful loadRuleConfig', async () => {
       fetchMock.mockResolvedValueOnce({

--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -17,6 +17,10 @@ export interface GameScore {
   id?: string
   team1Score: number
   team2Score: number
+  teamAAttackerId?: string
+  teamADefenderId?: string
+  teamBAttackerId?: string
+  teamBDefenderId?: string
 }
 
 export interface RuleConfig {
@@ -36,7 +40,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
   const ruleConfig = ref<RuleConfig | null>(null)
   const games = ref<GameScore[]>([])
   const currentGame = ref<GameScore>({ team1Score: 0, team2Score: 0 })
-  const matchState = ref<'draft' | 'score_entry' | 'ready_for_submission'>('draft')
+  const matchState = ref<'draft' | 'score_entry' | 'ready_for_submission' | 'position_swap'>('draft')
 
   async function fetchDefaults() {
     try {
@@ -190,12 +194,47 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     if (wasMatchComplete) {
       matchState.value = 'ready_for_submission';
     } else {
-      currentGame.value = { team1Score: 0, team2Score: 0 };
+      const prevGame = currentGame.value;
+      currentGame.value = {
+        team1Score: 0,
+        team2Score: 0,
+        teamAAttackerId: prevGame.teamAAttackerId,
+        teamADefenderId: prevGame.teamADefenderId,
+        teamBAttackerId: prevGame.teamBAttackerId,
+        teamBDefenderId: prevGame.teamBDefenderId
+      };
+      if (matchType.value === MatchType.TWO_VS_TWO) {
+        matchState.value = 'position_swap'
+      }
     }
   }
 
   function beginScoreEntry() {
+    if (matchType.value === MatchType.TWO_VS_TWO) {
+      matchState.value = 'position_swap'
+      currentGame.value.teamAAttackerId = selectedPlayers.value[0]
+      currentGame.value.teamADefenderId = selectedPlayers.value[1]
+      currentGame.value.teamBAttackerId = selectedPlayers.value[2]
+      currentGame.value.teamBDefenderId = selectedPlayers.value[3]
+    } else {
+      matchState.value = 'score_entry'
+    }
+  }
+
+  function confirmPositions() {
     matchState.value = 'score_entry'
+  }
+
+  function swapPositions(team: 1 | 2) {
+    if (team === 1) {
+      const temp = currentGame.value.teamAAttackerId
+      currentGame.value.teamAAttackerId = currentGame.value.teamADefenderId
+      currentGame.value.teamADefenderId = temp
+    } else {
+      const temp = currentGame.value.teamBAttackerId
+      currentGame.value.teamBAttackerId = currentGame.value.teamBDefenderId
+      currentGame.value.teamBDefenderId = temp
+    }
   }
 
   function returnToDraft() {
@@ -269,7 +308,14 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
       teamADefenderId,
       teamBAttackerId,
       teamBDefenderId,
-      games: games.value.map(g => ({ teamAScore: g.team1Score, teamBScore: g.team2Score }))
+      games: games.value.map(g => ({
+        teamAScore: g.team1Score,
+        teamBScore: g.team2Score,
+        teamAAttackerId: g.teamAAttackerId,
+        teamADefenderId: g.teamADefenderId,
+        teamBAttackerId: g.teamBAttackerId,
+        teamBDefenderId: g.teamBDefenderId
+      }))
     }
 
     startTimer({ idempotencyKey, payload })
@@ -324,6 +370,8 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     decrementScore,
     undoLastGame,
     beginScoreEntry,
+    confirmPositions,
+    swapPositions,
     returnToDraft,
     reset
   }

--- a/src/main/java/com/tictactore/dto/GameDto.java
+++ b/src/main/java/com/tictactore/dto/GameDto.java
@@ -3,7 +3,17 @@ package com.tictactore.dto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import java.util.UUID;
+
 public record GameDto(
     @Min(0) @Max(100) int teamAScore,
-    @Min(0) @Max(100) int teamBScore
-) {}
+    @Min(0) @Max(100) int teamBScore,
+    UUID teamAAttackerId,
+    UUID teamADefenderId,
+    UUID teamBAttackerId,
+    UUID teamBDefenderId
+) {
+    public GameDto(int teamAScore, int teamBScore) {
+        this(teamAScore, teamBScore, null, null, null, null);
+    }
+}

--- a/src/main/java/com/tictactore/exception/DuplicatePositionException.java
+++ b/src/main/java/com/tictactore/exception/DuplicatePositionException.java
@@ -1,0 +1,7 @@
+package com.tictactore.exception;
+
+public class DuplicatePositionException extends RuntimeException {
+    public DuplicatePositionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tictactore/exception/InvalidPositionException.java
+++ b/src/main/java/com/tictactore/exception/InvalidPositionException.java
@@ -1,0 +1,7 @@
+package com.tictactore.exception;
+
+public class InvalidPositionException extends RuntimeException {
+    public InvalidPositionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tictactore/model/Game.java
+++ b/src/main/java/com/tictactore/model/Game.java
@@ -31,6 +31,31 @@ public class Game {
     @Column(name = "team_b_score", nullable = false)
     private int teamBScore;
 
+    @Column(name = "team_a_attacker_id")
+    private UUID teamAAttackerId;
+
+    @Column(name = "team_a_defender_id")
+    private UUID teamADefenderId;
+
+    @Column(name = "team_b_attacker_id")
+    private UUID teamBAttackerId;
+
+    @Column(name = "team_b_defender_id")
+    private UUID teamBDefenderId;
+
     @Version
     private Long version;
+
+    public Position getPositionForPlayer(UUID playerId) {
+        if (playerId == null) {
+            return null;
+        }
+        if (playerId.equals(teamAAttackerId) || playerId.equals(teamBAttackerId)) {
+            return Position.ATTACKER;
+        }
+        if (playerId.equals(teamADefenderId) || playerId.equals(teamBDefenderId)) {
+            return Position.DEFENDER;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/tictactore/model/Position.java
+++ b/src/main/java/com/tictactore/model/Position.java
@@ -1,0 +1,6 @@
+package com.tictactore.model;
+
+public enum Position {
+    ATTACKER,
+    DEFENDER
+}

--- a/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
+++ b/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
@@ -4,7 +4,9 @@ import com.tictactore.dto.CreateMatchRequest;
 import com.tictactore.dto.GameDto;
 import com.tictactore.dto.MatchResponse;
 import com.tictactore.exception.DuplicatePlayerException;
+import com.tictactore.exception.DuplicatePositionException;
 import com.tictactore.exception.InvalidMatchScoreException;
+import com.tictactore.exception.InvalidPositionException;
 import com.tictactore.exception.ParticipantNotFoundException;
 import com.tictactore.model.Game;
 import com.tictactore.model.Match;
@@ -87,10 +89,39 @@ public class MatchServiceImpl implements MatchService {
 
         for (int i = 0; i < request.games().size(); i++) {
             GameDto dto = request.games().get(i);
+
+            if (request.teamADefenderId() == null) {
+                if (dto.teamAAttackerId() != null || dto.teamADefenderId() != null ||
+                    dto.teamBAttackerId() != null || dto.teamBDefenderId() != null) {
+                    throw new InvalidPositionException("1v1 matches must not contain positional data");
+                }
+            } else {
+                if (dto.teamAAttackerId() == null || dto.teamADefenderId() == null ||
+                    dto.teamBAttackerId() == null || dto.teamBDefenderId() == null) {
+                    throw new InvalidPositionException("2v2 games must contain positional data");
+                }
+
+                Set<UUID> gamePositions = new HashSet<>(Arrays.asList(
+                    dto.teamAAttackerId(), dto.teamADefenderId(),
+                    dto.teamBAttackerId(), dto.teamBDefenderId()
+                ));
+                if (gamePositions.size() != 4) {
+                    throw new DuplicatePositionException("Same player selected in multiple positions");
+                }
+
+                if (!gamePositions.equals(uniqueIds)) {
+                    throw new InvalidPositionException("Game players must match match players");
+                }
+            }
+
             Game game = Game.builder()
                     .gameOrder(i + 1)
                     .teamAScore(dto.teamAScore())
                     .teamBScore(dto.teamBScore())
+                    .teamAAttackerId(dto.teamAAttackerId())
+                    .teamADefenderId(dto.teamADefenderId())
+                    .teamBAttackerId(dto.teamBAttackerId())
+                    .teamBDefenderId(dto.teamBDefenderId())
                     .build();
             match.addGame(game);
         }
@@ -101,7 +132,11 @@ public class MatchServiceImpl implements MatchService {
 
     private MatchResponse mapToResponse(Match match) {
         List<GameDto> gameDtos = match.getGames().stream()
-                .map(g -> new GameDto(g.getTeamAScore(), g.getTeamBScore()))
+                .map(g -> new GameDto(
+                    g.getTeamAScore(), g.getTeamBScore(),
+                    g.getTeamAAttackerId(), g.getTeamADefenderId(),
+                    g.getTeamBAttackerId(), g.getTeamBDefenderId()
+                ))
                 .collect(Collectors.toList());
 
         return new MatchResponse(

--- a/src/main/resources/db/migration/V6__add_player_positions.sql
+++ b/src/main/resources/db/migration/V6__add_player_positions.sql
@@ -1,0 +1,4 @@
+ALTER TABLE game ADD COLUMN team_a_attacker_id UUID;
+ALTER TABLE game ADD COLUMN team_a_defender_id UUID;
+ALTER TABLE game ADD COLUMN team_b_attacker_id UUID;
+ALTER TABLE game ADD COLUMN team_b_defender_id UUID;

--- a/src/test/java/com/tictactore/service/MatchServiceATDDTest.java
+++ b/src/test/java/com/tictactore/service/MatchServiceATDDTest.java
@@ -66,7 +66,7 @@ class MatchServiceATDDTest {
         @Test
         @DisplayName("[P0] Should save match with PENDING_APPROVAL status when 4 distinct players and valid game scores provided")
         void shouldCreateMatchSuccessfully() {
-            var request = new CreateMatchRequest("key-123", p1, p1, p2, p3, p4, List.of(new GameDto(10, 8)));
+            var request = new CreateMatchRequest("key-123", p1, p1, p2, p3, p4, List.of(new GameDto(10, 8, p1, p2, p3, p4)));
             when(matchRepository.findByIdempotencyKey("key-123")).thenReturn(Optional.empty());
             when(userRepository.findAllById(any())).thenReturn(List.of(
                     User.builder().id(p1).build(),
@@ -97,7 +97,7 @@ class MatchServiceATDDTest {
         @Test
         @DisplayName("[P1] Should throw DuplicatePlayerException when same player selected in multiple positions")
         void shouldRejectDuplicatePlayers() {
-            var request = new CreateMatchRequest("key-123", p1, p1, p1, p3, p4, List.of(new GameDto(10, 8)));
+            var request = new CreateMatchRequest("key-123", p1, p1, p1, p3, p4, List.of(new GameDto(10, 8, p1, p1, p3, p4)));
             assertThatThrownBy(() -> matchService.createMatch(request))
                     .isInstanceOf(DuplicatePlayerException.class);
         }
@@ -105,7 +105,7 @@ class MatchServiceATDDTest {
         @Test
         @DisplayName("[P1] Should throw InvalidMatchScoreException when game scores exceed limits or have negative numbers")
         void shouldRejectInvalidGameScores() {
-            var request = new CreateMatchRequest("key-123", p1, p1, p2, p3, p4, List.of(new GameDto(-1, 8)));
+            var request = new CreateMatchRequest("key-123", p1, p1, p2, p3, p4, List.of(new GameDto(-1, 8, p1, p2, p3, p4)));
             when(userRepository.findAllById(any())).thenReturn(List.of(
                     User.builder().id(p1).build(),
                     User.builder().id(p2).build(),
@@ -119,7 +119,7 @@ class MatchServiceATDDTest {
         @Test
         @DisplayName("[P1] Should throw ParticipantNotFoundException when player ID does not exist in database")
         void shouldRejectNonExistentParticipant() {
-            var request = new CreateMatchRequest("key-123", p1, p1, p2, p3, p4, List.of(new GameDto(10, 8)));
+            var request = new CreateMatchRequest("key-123", p1, p1, p2, p3, p4, List.of(new GameDto(10, 8, p1, p2, p3, p4)));
             when(userRepository.findAllById(any())).thenReturn(List.of(User.builder().id(p1).build()));
             assertThatThrownBy(() -> matchService.createMatch(request))
                     .isInstanceOf(ParticipantNotFoundException.class);

--- a/src/test/java/com/tictactore/service/MatchServiceTest.java
+++ b/src/test/java/com/tictactore/service/MatchServiceTest.java
@@ -4,7 +4,9 @@ import com.tictactore.dto.CreateMatchRequest;
 import com.tictactore.dto.GameDto;
 import com.tictactore.dto.MatchResponse;
 import com.tictactore.exception.DuplicatePlayerException;
+import com.tictactore.exception.DuplicatePositionException;
 import com.tictactore.exception.InvalidMatchScoreException;
+import com.tictactore.exception.InvalidPositionException;
 import com.tictactore.exception.ParticipantNotFoundException;
 import com.tictactore.model.Match;
 import com.tictactore.model.User;
@@ -68,7 +70,7 @@ class MatchServiceTest {
             CreateMatchRequest request = new CreateMatchRequest(
                     "idempotency-123",
                     p1, p1, p2, p3, p4,
-                    List.of(new GameDto(10, 8), new GameDto(10, 6))
+                    List.of(new GameDto(10, 8, p1, p2, p3, p4), new GameDto(10, 6, p1, p2, p3, p4))
             );
 
             when(matchRepository.findByIdempotencyKey("idempotency-123")).thenReturn(Optional.empty());
@@ -110,7 +112,7 @@ class MatchServiceTest {
             CreateMatchRequest request = new CreateMatchRequest(
                     "idempotency-456",
                     p1, p1, p1, p3, p4, // p1 duplicated
-                    List.of(new GameDto(10, 8))
+                    List.of(new GameDto(10, 8, p1, p1, p3, p4))
             );
 
             // When / Then
@@ -128,7 +130,7 @@ class MatchServiceTest {
             CreateMatchRequest request = new CreateMatchRequest(
                     "idempotency-789",
                     p1, p1, p2, p3, p4,
-                    List.of(new GameDto(101, 8)) // score > 100
+                    List.of(new GameDto(101, 8, p1, p2, p3, p4)) // score > 100
             );
 
             when(matchRepository.findByIdempotencyKey("idempotency-789")).thenReturn(Optional.empty());
@@ -154,7 +156,7 @@ class MatchServiceTest {
             CreateMatchRequest request = new CreateMatchRequest(
                     "idempotency-999",
                     p1, p1, p2, p3, p4,
-                    List.of(new GameDto(10, 8))
+                    List.of(new GameDto(10, 8, p1, p2, p3, p4))
             );
 
             when(matchRepository.findByIdempotencyKey("idempotency-999")).thenReturn(Optional.empty());
@@ -164,6 +166,109 @@ class MatchServiceTest {
             assertThatThrownBy(() -> matchService.createMatch(request))
                     .isInstanceOf(ParticipantNotFoundException.class)
                     .hasMessageContaining("Player not found with ID");
+
+            verifyNoInteractions(matchOperation);
+        }
+
+        @Test
+        @DisplayName("[P1] Should throw InvalidPositionException when 1v1 match contains positional data")
+        void shouldReject1v1PositionalData() {
+            // Given
+            CreateMatchRequest request = new CreateMatchRequest(
+                    "idempotency-pos-1",
+                    p1, p1, null, p3, null,
+                    List.of(new GameDto(10, 8, p1, null, null, null))
+            );
+
+            when(matchRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+            when(userRepository.findAllById(any())).thenReturn(List.of(
+                    User.builder().id(p1).build(),
+                    User.builder().id(p3).build()
+            ));
+
+            // When / Then
+            assertThatThrownBy(() -> matchService.createMatch(request))
+                    .isInstanceOf(InvalidPositionException.class)
+                    .hasMessageContaining("1v1 matches must not contain positional data");
+
+            verifyNoInteractions(matchOperation);
+        }
+
+        @Test
+        @DisplayName("[P1] Should throw InvalidPositionException when 2v2 match game lacks positional data")
+        void shouldReject2v2MissingPositionalData() {
+            // Given
+            CreateMatchRequest request = new CreateMatchRequest(
+                    "idempotency-pos-2",
+                    p1, p1, p2, p3, p4,
+                    List.of(new GameDto(10, 8, p1, p2, null, p4))
+            );
+
+            when(matchRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+            when(userRepository.findAllById(any())).thenReturn(List.of(
+                    User.builder().id(p1).build(),
+                    User.builder().id(p2).build(),
+                    User.builder().id(p3).build(),
+                    User.builder().id(p4).build()
+            ));
+
+            // When / Then
+            assertThatThrownBy(() -> matchService.createMatch(request))
+                    .isInstanceOf(InvalidPositionException.class)
+                    .hasMessageContaining("2v2 games must contain positional data");
+
+            verifyNoInteractions(matchOperation);
+        }
+
+        @Test
+        @DisplayName("[P1] Should throw DuplicatePositionException when 2v2 game contains duplicate positional players")
+        void shouldReject2v2DuplicatePositionalData() {
+            // Given
+            CreateMatchRequest request = new CreateMatchRequest(
+                    "idempotency-pos-3",
+                    p1, p1, p2, p3, p4,
+                    List.of(new GameDto(10, 8, p1, p1, p3, p4))
+            );
+
+            when(matchRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+            when(userRepository.findAllById(any())).thenReturn(List.of(
+                    User.builder().id(p1).build(),
+                    User.builder().id(p2).build(),
+                    User.builder().id(p3).build(),
+                    User.builder().id(p4).build()
+            ));
+
+            // When / Then
+            assertThatThrownBy(() -> matchService.createMatch(request))
+                    .isInstanceOf(DuplicatePositionException.class)
+                    .hasMessageContaining("Same player selected in multiple positions");
+
+            verifyNoInteractions(matchOperation);
+        }
+
+        @Test
+        @DisplayName("[P1] Should throw InvalidPositionException when 2v2 game players do not match match players")
+        void shouldReject2v2MismatchMatchPlayers() {
+            // Given
+            UUID p5 = UUID.randomUUID();
+            CreateMatchRequest request = new CreateMatchRequest(
+                    "idempotency-pos-4",
+                    p1, p1, p2, p3, p4,
+                    List.of(new GameDto(10, 8, p1, p2, p3, p5))
+            );
+
+            when(matchRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+            when(userRepository.findAllById(any())).thenReturn(List.of(
+                    User.builder().id(p1).build(),
+                    User.builder().id(p2).build(),
+                    User.builder().id(p3).build(),
+                    User.builder().id(p4).build()
+            ));
+
+            // When / Then
+            assertThatThrownBy(() -> matchService.createMatch(request))
+                    .isInstanceOf(InvalidPositionException.class)
+                    .hasMessageContaining("Game players must match match players");
 
             verifyNoInteractions(matchOperation);
         }


### PR DESCRIPTION
🎯 **What**
Added player position fields to the game models, along with validation on the backend to enforce positional rules for 2v2 and 1v1 match games. On the frontend, added a modal `PositionSwapDialog` that allows players to switch positions before each game starts.

💡 **Why**
This satisfies the acceptance criteria for Story 2.5, ensuring that 2v2 player-level statistics remain accurate by letting players declare and swap Attacker/Defender roles between games.

✅ **Verification**
Ran all Java and Pinia test suites, added validations for position mappings, and wrote Playwright frontend tests confirming the new UI behaves properly upon state transition. E2E visually verified using screenshots via playwright verification instructions tool.

✨ **Result**
Players can now correctly configure their positional status between games before moving to score entry in a 2v2 match, and the backend robustly accepts/rejects configurations based on the match type.

---
*PR created automatically by Jules for task [15783299384134637998](https://jules.google.com/task/15783299384134637998) started by @phalbohr*