### PR TITLE
🐛 fix: keep ScoreEntry mounted during position_swap state

### DIFF
--- a/frontend/src/features/match/components/NewMatchFlow.vue
+++ b/frontend/src/features/match/components/NewMatchFlow.vue
@@ -82,7 +82,7 @@ function handleMatchReady() {
   </div>
   
   <ScoreEntry 
-    v-else-if="store.matchState === 'score_entry' || store.matchState === 'ready_for_submission'" 
+    v-else-if="store.matchState === 'score_entry' || store.matchState === 'ready_for_submission' || store.matchState === 'position_swap'"
     @complete="handleMatchReady" 
     @cancel="handleCancel" 
     @back="handleBack"


### PR DESCRIPTION
🎯 What: Updated `NewMatchFlow.vue` to include `store.matchState === 'position_swap'` in the `v-else-if` condition for the `ScoreEntry` component.
💡 Why: To prevent the flow from unmounting and showing an invalid state screen when transitioning to the `position_swap` state.
✅ Verification: Ran frontend unit tests and verified all tests passed successfully.
✨ Result: The `ScoreEntry` component (which renders `PositionSwapDialog`) now remains correctly mounted during the `position_swap` state transition.

---
*PR created automatically by Jules for task [9115217542893763945](https://jules.google.com/task/9115217542893763945) started by @phalbohr*