### PR TITLE
🐛 Fix match submission to always include completed active game

### DIFF
--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -289,7 +289,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     const requiredPlayers = matchType.value === MatchType.TWO_VS_TWO ? 4 : 2
     if (selectedPlayers.value.length < requiredPlayers) return
 
-    if (games.value.length === 0 && isGameComplete.value) {
+    if (isGameComplete.value) {
       completeCurrentGame()
     }
     if (games.value.length === 0) return


### PR DESCRIPTION
🎯 What
Modified `startSubmissionTimer()` in `matchDraftStore.ts` to always call `completeCurrentGame()` if `isGameComplete` is true, regardless of whether there are other games already in `games.value`.

💡 Why
Previously, the check `if (games.value.length === 0 && isGameComplete.value)` only saved the active game if it was the very first game. This caused subsequent active games that met completion criteria (like reaching score limit) to be dropped when submitting the match payload.

✅ Verification
Ran `npm run test:unit --prefix frontend` locally to ensure no regressions in match store logic. The fix was tested against the provided scenarios where games > 0 and the final game is also complete.

✨ Result
Clicking submit now correctly appends the active, complete game to the payload rather than dropping it.

---
*PR created automatically by Jules for task [10443045413663946938](https://jules.google.com/task/10443045413663946938) started by @phalbohr*