### PR TITLE
✨ [test] Add unit tests for 2v2 position swapping in matchDraftStore

### DIFF
--- a/frontend/src/features/match/stores/matchDraftStore.spec.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.spec.ts
@@ -91,6 +91,42 @@ describe('matchDraftStore', () => {
       store.confirmPositions()
       expect(store.matchState).toBe('score_entry')
     })
+
+    it('swaps positions for team 2', () => {
+      const store = useMatchDraftStore()
+      store.setMatchType(MatchType.TWO_VS_TWO)
+      store.addPlayer('p1')
+      store.addPlayer('p2')
+      store.addPlayer('p3')
+      store.addPlayer('p4')
+
+      store.beginScoreEntry()
+      expect(store.currentGame.teamBAttackerId).toBe('p3')
+      expect(store.currentGame.teamBDefenderId).toBe('p4')
+
+      store.swapPositions(2)
+      expect(store.currentGame.teamBAttackerId).toBe('p4')
+      expect(store.currentGame.teamBDefenderId).toBe('p3')
+    })
+
+    it('swaps positions back and forth', () => {
+      const store = useMatchDraftStore()
+      store.setMatchType(MatchType.TWO_VS_TWO)
+      store.addPlayer('p1')
+      store.addPlayer('p2')
+      store.addPlayer('p3')
+      store.addPlayer('p4')
+
+      store.beginScoreEntry()
+
+      store.swapPositions(1)
+      expect(store.currentGame.teamAAttackerId).toBe('p2')
+      expect(store.currentGame.teamADefenderId).toBe('p1')
+
+      store.swapPositions(1)
+      expect(store.currentGame.teamAAttackerId).toBe('p1')
+      expect(store.currentGame.teamADefenderId).toBe('p2')
+    })
   })
 
   describe('Score Entry and Manual Completion', () => {
@@ -312,6 +348,41 @@ describe('matchDraftStore', () => {
       }))
       expect(store.isPendingSubmission).toBe(false)
       expect(store.pendingSubmission).toBeNull()
+    })
+
+    it('preserves swapped position mapping in submission payload', () => {
+      const store = useMatchDraftStore()
+      store.setMatchType(MatchType.TWO_VS_TWO)
+      store.addPlayer('p1')
+      store.addPlayer('p2')
+      store.addPlayer('p3')
+      store.addPlayer('p4')
+      store.ruleConfig = { scoreLimit: 5, gameLimit: 1, winsNeeded: 1, winByTwo: false }
+
+      store.beginScoreEntry()
+      store.swapPositions(1) // swap team 1 (p1/p2 -> p2/p1)
+      store.swapPositions(2) // swap team 2 (p3/p4 -> p4/p3)
+      store.confirmPositions()
+
+      store.incrementScore(1, 5)
+      store.completeCurrentGame()
+
+      store.startSubmissionTimer()
+
+      expect(store.pendingSubmission).not.toBeNull()
+      const payload = store.pendingSubmission?.payload
+
+      // The overall match attackers/defenders come from selectedPlayers
+      expect(payload?.teamAAttackerId).toBe('p1')
+      expect(payload?.teamADefenderId).toBe('p2')
+      expect(payload?.teamBAttackerId).toBe('p3')
+      expect(payload?.teamBDefenderId).toBe('p4')
+
+      // The game-specific attackers/defenders come from the swapped current game state
+      expect(payload?.games[0].teamAAttackerId).toBe('p2')
+      expect(payload?.games[0].teamADefenderId).toBe('p1')
+      expect(payload?.games[0].teamBAttackerId).toBe('p4')
+      expect(payload?.games[0].teamBDefenderId).toBe('p3')
     })
 
     it('aborts timer and restores ready_for_submission state when cancelSubmissionTimer is called', () => {


### PR DESCRIPTION
🎯 What
Added unit tests for 2v2 position swapping functionality in `matchDraftStore`.

💡 Why
To ensure the correctness and reliability of state transitions related to position swapping (between attacker and defender) for both teams, as well as preserving these mappings correctly during match submission.

✅ Verification
Ran Vitest unit tests which passed locally (`npm run test:unit --prefix frontend src/features/match/stores/matchDraftStore.spec.ts`).

✨ Result
Comprehensive test coverage provided for `swapPositions`, and `startSubmissionTimer` functionality when dealing with position swaps.

---
*PR created automatically by Jules for task [7575397736686381810](https://jules.google.com/task/7575397736686381810) started by @phalbohr*