### PR TITLE
🐛 Fix exception thrown for asymmetric defender validation

### DIFF
--- a/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
+++ b/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
@@ -42,7 +42,7 @@ public class MatchServiceImpl implements MatchService {
         }
 
         if ((request.teamADefenderId() == null) != (request.teamBDefenderId() == null)) {
-            throw new InvalidMatchScoreException("Asymmetric defenders: both teams must have a defender in 2v2 matches");
+            throw new InvalidPositionException("Asymmetric defenders: both teams must have a defender in 2v2 matches");
         }
 
         List<UUID> playerIds = new ArrayList<>();


### PR DESCRIPTION
🎯 What: Changed the exception thrown when a request has asymmetric defenders (i.e. one team has a defender and the other does not) from `InvalidMatchScoreException` to `InvalidPositionException` in `MatchServiceImpl`.
💡 Why: The asymmetric defender check is evaluating team positions, not match scores, so `InvalidPositionException` more accurately represents the validation failure and fulfills the acceptance criteria.
✅ Verification: Ran existing unit tests for `MatchService` and `MatchServiceATDDTest` using `mvn test`, which all passed successfully, ensuring no regressions.
✨ Result: `MatchService` now throws the correct domain exception when invalid player positions (asymmetric defenders) are provided.

---
*PR created automatically by Jules for task [2188390800337669694](https://jules.google.com/task/2188390800337669694) started by @phalbohr*