### PR TITLE
✨ Enforce match creator belongs to match participants

### DIFF
--- a/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
+++ b/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
@@ -56,6 +56,10 @@ public class MatchServiceImpl implements MatchService {
             throw new DuplicatePlayerException("Same player selected in multiple positions");
         }
 
+        if (request.creatorId() != null && !uniqueIds.contains(request.creatorId())) {
+            throw new ParticipantNotFoundException("Creator must be a participant in the match");
+        }
+
         List<User> foundUsers = userRepository.findAllById(playerIds);
         if (foundUsers.size() != playerIds.size()) {
             Set<UUID> foundIds = foundUsers.stream().map(User::getId).collect(Collectors.toSet());

--- a/src/test/java/com/tictactore/service/MatchServiceTest.java
+++ b/src/test/java/com/tictactore/service/MatchServiceTest.java
@@ -247,6 +247,23 @@ class MatchServiceTest {
         }
 
         @Test
+        @DisplayName("[P1] Should throw ParticipantNotFoundException when creatorId does not belong to match participants")
+        void shouldRejectCreatorNotParticipant() {
+            UUID nonParticipantCreator = UUID.randomUUID();
+            CreateMatchRequest request = new CreateMatchRequest(
+                    "idempotency-1000",
+                    nonParticipantCreator, p1, p2, p3, p4,
+                    List.of(new GameDto(10, 8, p1, p2, p3, p4))
+            );
+
+            assertThatThrownBy(() -> matchService.createMatch(request))
+                    .isInstanceOf(ParticipantNotFoundException.class)
+                    .hasMessageContaining("Creator must be a participant in the match");
+
+            verifyNoInteractions(matchOperation);
+        }
+
+        @Test
         @DisplayName("[P1] Should throw InvalidPositionException when 2v2 game players do not match match players")
         void shouldReject2v2MismatchMatchPlayers() {
             // Given


### PR DESCRIPTION
🎯 What
Added a validation step in `MatchServiceImpl` to enforce that the `creatorId`, if provided during match creation, is one of the players participating in the match. Also added a corresponding unit test to `MatchServiceTest`.

💡 Why
To ensure data integrity, a match creator must be a participant in the match. Allowing non-participants to create matches could lead to unauthorized or disconnected data states.

✅ Verification
- Ensured unit test covers the case where `creatorId` is provided but is not part of the match participants.
- Verified that all unit tests (`./mvnw test`) pass locally.
- Checked that the newly added test adheres to the project's zero-comment rule.

✨ Result
Match creation API now rejects requests where the `creatorId` is not in the list of participants, throwing a `ParticipantNotFoundException` to map correctly to HTTP status codes.

---
*PR created automatically by Jules for task [8930033050641034874](https://jules.google.com/task/8930033050641034874) started by @phalbohr*