### PR TITLE
✨ Enforce strict team boundaries for player positions in 2v2 games

### DIFF
--- a/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
+++ b/src/main/java/com/tictactore/service/impl/MatchServiceImpl.java
@@ -112,6 +112,15 @@ public class MatchServiceImpl implements MatchService {
                 if (!gamePositions.equals(uniqueIds)) {
                     throw new InvalidPositionException("Game players must match match players");
                 }
+
+                Set<UUID> matchTeamA = Set.of(request.teamAAttackerId(), request.teamADefenderId());
+                Set<UUID> matchTeamB = Set.of(request.teamBAttackerId(), request.teamBDefenderId());
+                Set<UUID> gameTeamA = Set.of(dto.teamAAttackerId(), dto.teamADefenderId());
+                Set<UUID> gameTeamB = Set.of(dto.teamBAttackerId(), dto.teamBDefenderId());
+
+                if (!matchTeamA.equals(gameTeamA) || !matchTeamB.equals(gameTeamB)) {
+                    throw new InvalidPositionException("Team A players cannot be assigned to Team B positions");
+                }
             }
 
             Game game = Game.builder()

--- a/src/test/java/com/tictactore/service/MatchServiceTest.java
+++ b/src/test/java/com/tictactore/service/MatchServiceTest.java
@@ -272,5 +272,29 @@ class MatchServiceTest {
 
             verifyNoInteractions(matchOperation);
         }
+        @Test
+        @DisplayName("[P1] Should throw InvalidPositionException when Team A player is assigned to Team B position")
+        void shouldReject2v2SwappingTeamPositions() {
+            var request = new CreateMatchRequest(
+                    "idempotency-pos-5",
+                    p1, p1, p2, p3, p4,
+                    List.of(new GameDto(10, 8, p1, p3, p2, p4))
+            );
+
+            when(matchRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+            when(userRepository.findAllById(any())).thenReturn(List.of(
+                    User.builder().id(p1).build(),
+                    User.builder().id(p2).build(),
+                    User.builder().id(p3).build(),
+                    User.builder().id(p4).build()
+            ));
+
+            assertThatThrownBy(() -> matchService.createMatch(request))
+                    .isInstanceOf(InvalidPositionException.class)
+                    .hasMessageContaining("Team A players cannot be assigned to Team B positions");
+
+            verifyNoInteractions(matchOperation);
+        }
+
     }
 }


### PR DESCRIPTION
🎯 What: Added validation to `MatchServiceImpl` ensuring players in 2v2 games strictly belong to the Team A/Team B they were assigned to in the Match creation header. Throws `InvalidPositionException` if Team A players are assigned to Team B positions (or vice versa).
💡 Why: To prevent malicious payloads or bugs from letting users swap teams arbitrarily within games, which breaks the consistency of 2v2 team formats.
✅ Verification: Backend unit tests modified with a new test `shouldReject2v2SwappingTeamPositions` simulating the issue to ensure an `InvalidPositionException` is properly thrown.
✨ Result: Payloads attempting to place a Team A match player into a Team B game slot are fully rejected.

---
*PR created automatically by Jules for task [8425899374387216849](https://jules.google.com/task/8425899374387216849) started by @phalbohr*