### PR TITLE
🐛 Handle client-side 4xx errors on match submission

### DIFF
--- a/frontend/src/features/match/components/ErrorToast.vue
+++ b/frontend/src/features/match/components/ErrorToast.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import BaseButton from '@/core/components/BaseButton.vue'
+
+defineProps<{
+  message: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'dismiss'): void
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <Transition name="toast-slide">
+    <div
+      class="fixed bottom-6 left-4 right-4 z-50 max-w-md mx-auto bg-error-container text-on-error-container rounded-2xl p-4 shadow-2xl flex items-center justify-between gap-4"
+      role="alert"
+      aria-live="assertive"
+    >
+      <div class="flex items-center gap-3">
+        <span class="text-sm font-medium">
+          {{ message }}
+        </span>
+      </div>
+
+      <BaseButton
+        variant="secondary"
+        @click="emit('dismiss')"
+        class="!h-10 px-4 text-xs font-bold"
+      >
+        {{ t('common.close', 'Close') }}
+      </BaseButton>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.toast-slide-enter-active,
+.toast-slide-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.toast-slide-enter-from,
+.toast-slide-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+</style>

--- a/frontend/src/features/match/composables/useSubmissionTimer.ts
+++ b/frontend/src/features/match/composables/useSubmissionTimer.ts
@@ -36,6 +36,11 @@ export function useSubmissionTimer(commitCallback: (payload: PendingSubmissionPa
           const result = await commitCallback(payload)
           if (result === SubmissionResult.SERVER_OR_NETWORK_ERROR) {
             isOfflinePending.value = true
+          } else if (result === SubmissionResult.CLIENT_ERROR) {
+            isPending.value = false
+            pendingSubmission.value = null
+            // For client errors we do NOT want to mark it as offline pending
+            // We just clear the timer and let the caller handle the error state
           } else {
             isPending.value = false
             pendingSubmission.value = null

--- a/frontend/src/features/match/stores/matchDraftStore.ts
+++ b/frontend/src/features/match/stores/matchDraftStore.ts
@@ -41,6 +41,11 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
   const games = ref<GameScore[]>([])
   const currentGame = ref<GameScore>({ team1Score: 0, team2Score: 0 })
   const matchState = ref<'draft' | 'score_entry' | 'ready_for_submission' | 'position_swap'>('draft')
+  const submitError = ref<string | null>(null)
+
+  function clearSubmitError() {
+    submitError.value = null
+  }
 
   async function fetchDefaults() {
     try {
@@ -266,6 +271,14 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
         resetDraftStateOnly()
         return SubmissionResult.SUCCESS
       } else if (res.status >= 400 && res.status < 500) {
+        let msg = 'Failed to submit match'
+        try {
+          const data = await res.json()
+          if (data.message) msg = data.message
+        } catch {
+          // ignore parsing error
+        }
+        submitError.value = msg
         return SubmissionResult.CLIENT_ERROR
       } else {
         return SubmissionResult.SERVER_OR_NETWORK_ERROR
@@ -286,6 +299,8 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
   } = useSubmissionTimer(executeCommit)
 
   function startSubmissionTimer() {
+    clearSubmitError()
+
     const requiredPlayers = matchType.value === MatchType.TWO_VS_TWO ? 4 : 2
     if (selectedPlayers.value.length < requiredPlayers) return
 
@@ -334,6 +349,7 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     games.value = []
     currentGame.value = { team1Score: 0, team2Score: 0 }
     matchState.value = 'draft'
+    clearSubmitError()
   }
 
   function reset() {
@@ -355,6 +371,8 @@ export const useMatchDraftStore = defineStore('matchDraft', () => {
     games,
     currentGame,
     matchState,
+    submitError,
+    clearSubmitError,
     pendingSubmission,
     isPendingSubmission,
     isOfflinePending,

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -11,6 +11,7 @@ import StatsDashboard from '@/features/stats/components/StatsDashboard.vue'
 import EmptyStateCTA from '@/features/stats/components/EmptyStateCTA.vue'
 import NewMatchFlow from '@/features/match/components/NewMatchFlow.vue'
 import UndoToast from '@/features/match/components/UndoToast.vue'
+import ErrorToast from '@/features/match/components/ErrorToast.vue'
 import BaseButton from '@/core/components/BaseButton.vue'
 import { useMatchDraftStore } from '@/features/match/stores/matchDraftStore'
 import { ref } from 'vue'
@@ -30,6 +31,16 @@ function handleUndo() {
   matchStore.cancelSubmissionTimer()
   showNewMatch.value = true
 }
+
+function handleDismissError() {
+  matchStore.clearSubmitError()
+}
+
+watch(() => matchStore.submitError, (newVal) => {
+  if (newVal) {
+    showNewMatch.value = true
+  }
+})
 
 onMounted(async () => {
   if (authStore.isAuthenticated) {
@@ -123,6 +134,12 @@ watch(() => authStore.isAuthenticated, async (newVal) => {
         :countdown="matchStore.submissionCountdown"
         :is-offline="matchStore.isOfflinePending"
         @undo="handleUndo"
+      />
+
+      <ErrorToast
+        v-if="matchStore.submitError"
+        :message="matchStore.submitError"
+        @dismiss="handleDismissError"
       />
     </main>
   </div>


### PR DESCRIPTION
🎯 What
This PR implements graceful handling for client-side 4xx errors during match submission. It ensures the UI informs the user, halts the retry loop, and keeps the match draft editable so the user can correct their input.

💡 Why
Currently, when a 4xx error is returned on match submission (e.g. invalid players or scores), the timer silently fails or behaves unexpectedly without giving the user feedback.

✅ Verification
- Unit and store tests verified.
- Pre-commit linting and type checking complete.
- Implemented `ErrorToast.vue` to show UI feedback.
- Manual Playwright script verification attempted; local server logic handled.

✨ Result
A more robust and user-friendly match submission flow that prevents data loss and frustration on validation errors.

---
*PR created automatically by Jules for task [4207238579444259041](https://jules.google.com/task/4207238579444259041) started by @phalbohr*